### PR TITLE
Implement Spotify Search API Integration

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -16,9 +16,9 @@ export default {
   getAvailableGenres() {
     return apiClient.get('/spotify/genres');
   },
-  getAudiobooks(limit = 40, offset = 0, market = 'AU') {
+  getAudiobooks(limit = 40, offset = 0, market = 'AU', query?: string) {
     return apiClient.get('/spotify/audiobooks', {
-      params: { limit, offset, market }
+      params: { limit, offset, market, query }
     });
-  }
+  },
 };

--- a/client/src/stores/__tests__/spotify.spec.ts
+++ b/client/src/stores/__tests__/spotify.spec.ts
@@ -33,7 +33,7 @@ describe('Spotify Store', () => {
       const store = useSpotifyStore()
       await store.fetchAudiobooks()
       
-      expect(api.getAudiobooks).toHaveBeenCalledWith(40, 0, 'AU')
+      expect(api.getAudiobooks).toHaveBeenCalledWith(40, 0, 'AU', undefined)
       expect(store.audiobooks).toEqual([{ id: '1', name: 'Test Audiobook' }])
       expect(store.isLoading).toBe(false)
       expect(store.error).toBeNull()
@@ -61,7 +61,19 @@ describe('Spotify Store', () => {
       const store = useSpotifyStore()
       await store.fetchAudiobooks(20, 10, 'US')
       
-      expect(api.getAudiobooks).toHaveBeenCalledWith(20, 10, 'US')
+      expect(api.getAudiobooks).toHaveBeenCalledWith(20, 10, 'US', undefined)
+    })
+
+    it('should pass search query to API', async () => {
+      // Type cast as any to avoid AxiosResponse typing issues in tests
+      vi.mocked(api.getAudiobooks).mockResolvedValue({
+        data: { audiobooks: { items: [] } }
+      } as any)
+      
+      const store = useSpotifyStore()
+      await store.fetchAudiobooks(40, 0, 'AU', 'harry potter')
+      
+      expect(api.getAudiobooks).toHaveBeenCalledWith(40, 0, 'AU', 'harry potter')
     })
   })
 })

--- a/client/src/stores/spotify.ts
+++ b/client/src/stores/spotify.ts
@@ -41,11 +41,11 @@ export const useSpotifyStore = defineStore('spotify', () => {
     }
   }
 
-  async function fetchAudiobooks(limit = 40, offset = 0, market = 'AU') {
+  async function fetchAudiobooks(limit = 40, offset = 0, market = 'AU', query?: string) {
     isLoading.value = true;
     error.value = null;
     try {
-      const response = await api.getAudiobooks(limit, offset, market);
+      const response = await api.getAudiobooks(limit, offset, market, query);
       const data = response.data as AudiobooksResponse;
       audiobooks.value = data.audiobooks.items;
     } catch (err: any) {

--- a/client/src/views/__tests__/AudiobooksView.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView.spec.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AudiobooksView from '../AudiobooksView.vue'
 
-// Mock the store
+// Mock store with function to track calls
+const fetchAudiobooksMock = vi.fn()
+
 vi.mock('@/stores/spotify', () => ({
   useSpotifyStore: () => ({
     audiobooks: [],
     isLoading: false,
     error: null,
-    fetchAudiobooks: vi.fn()
+    fetchAudiobooks: fetchAudiobooksMock
   })
 }))
 
@@ -22,9 +24,17 @@ vi.mock('@/components/AudiobookCard.vue', () => ({
   }
 }))
 
+// Mock setTimeout
+vi.useFakeTimers()
+
 describe('AudiobooksView', () => {
-  it('renders the AudiobooksView component', () => {
+  beforeEach(() => {
+    // Reset mock before each test
+    fetchAudiobooksMock.mockClear()
     setActivePinia(createPinia())
+  })
+
+  it('renders the AudiobooksView component', () => {
     const wrapper = mount(AudiobooksView)
     
     // Check if the component renders main sections
@@ -33,15 +43,58 @@ describe('AudiobooksView', () => {
     expect(wrapper.text()).toContain('Welcome to Audiobook Hub')
   })
   
-  it('has search input functionality', async () => {
-    setActivePinia(createPinia())
+  it('calls API when search input changes', async () => {  
     const wrapper = mount(AudiobooksView)
     
-    // Check if search input works
-    const searchInput = wrapper.find('.search-input')
-    await searchInput.setValue('test')
+    // Check that fetchAudiobooks was called once on mount
+    expect(fetchAudiobooksMock).toHaveBeenCalledTimes(1)
     
-    // Simply verify the setValue function works
-    expect(wrapper.find('.search-input').exists()).toBe(true)
+    // Enter search text
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('harry potter')
+    
+    // Fast forward timers to trigger the debounced search
+    vi.runAllTimers()
+    await flushPromises()
+    
+    // Check that fetchAudiobooks was called with search term
+    expect(fetchAudiobooksMock).toHaveBeenCalledTimes(2)
+    expect(fetchAudiobooksMock).toHaveBeenLastCalledWith(40, 0, 'AU', 'harry potter')
+  })
+  
+  it('has clear search functionality', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    // Enter search text
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('test query')
+    
+    // Check clear button appears
+    expect(wrapper.find('.clear-button').exists()).toBe(true)
+    
+    // Click clear button
+    await wrapper.find('.clear-button').trigger('click')
+    
+    // Check that search input is cleared
+    expect(wrapper.vm.searchQuery).toBe('')
+    
+    // Check that fetchAudiobooks was called without query
+    expect(fetchAudiobooksMock).toHaveBeenLastCalledWith()
+  })
+  
+  it('shows loading state while searching', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    // Enter search text
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('test query')
+    
+    // Manually set isSearching to true
+    wrapper.vm.isSearching = true
+    await wrapper.vm.$nextTick()
+    
+    // Check loading spinner is shown
+    expect(wrapper.find('.spinner').exists()).toBe(true)
+    expect(wrapper.find('.loading').text()).toContain('Searching...')
   })
 })

--- a/server/src/controllers/spotify.controller.js
+++ b/server/src/controllers/spotify.controller.js
@@ -22,8 +22,8 @@ class SpotifyController {
 
   async getAudiobooks(req, res, next) {
     try {
-      const { limit = 40, offset = 0, market = 'AU' } = req.query;
-      const data = await spotifyService.getAudiobooks(limit, offset, market);
+      const { limit = 40, offset = 0, market = 'AU', query = 'tag:new' } = req.query;
+      const data = await spotifyService.getAudiobooks(limit, offset, market, query);
       res.json(data);
     } catch (error) {
       next(error);

--- a/server/src/services/spotify.service.js
+++ b/server/src/services/spotify.service.js
@@ -72,14 +72,14 @@ class SpotifyService {
     }
   }
 
-  async getAudiobooks(limit = 40, offset = 0, market = 'AU') {
+  async getAudiobooks(limit = 40, offset = 0, market = 'AU', query = 'tag:new') {
     try {
       const token = await this.getToken();
       const response = await axios({
         method: 'get',
         url: `${this.baseUrl}/search`,
         params: {
-          q: 'tag:new',
+          q: query,
           type: 'audiobook',
           market,
           limit,

--- a/server/tests/integration/spotify.routes.test.js
+++ b/server/tests/integration/spotify.routes.test.js
@@ -79,4 +79,47 @@ describe('Spotify API Routes', () => {
         .expect(500);
     });
   });
+
+  describe('GET /api/spotify/audiobooks', () => {
+    it('should return audiobooks with default parameters', async () => {
+      // Mock the getAudiobooks method
+      const mockAudiobooks = {
+        audiobooks: {
+          items: [
+            { id: '1', name: 'Audiobook 1' },
+            { id: '2', name: 'Audiobook 2' }
+          ]
+        }
+      };
+      spotifyService.getAudiobooks.mockResolvedValue(mockAudiobooks);
+
+      const response = await request(app)
+        .get('/api/spotify/audiobooks')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body).toEqual(mockAudiobooks);
+      expect(spotifyService.getAudiobooks).toHaveBeenCalledWith(40, 0, 'AU', 'tag:new');
+    });
+
+    it('should pass custom parameters including search query to the service', async () => {
+      // Mock the getAudiobooks method
+      spotifyService.getAudiobooks.mockResolvedValue({ audiobooks: { items: [] } });
+
+      await request(app)
+        .get('/api/spotify/audiobooks?limit=10&offset=5&market=GB&query=harry%20potter')
+        .expect(200);
+
+      expect(spotifyService.getAudiobooks).toHaveBeenCalledWith(10, 5, 'GB', 'harry potter');
+    });
+
+    it('should handle errors from the service', async () => {
+      // Mock a service error
+      spotifyService.getAudiobooks.mockRejectedValue(new Error('API Error'));
+
+      await request(app)
+        .get('/api/spotify/audiobooks')
+        .expect(500);
+    });
+  });
 });

--- a/server/tests/unit/spotify.service.test.js
+++ b/server/tests/unit/spotify.service.test.js
@@ -16,7 +16,7 @@ describe('SpotifyService', () => {
   });
 
   describe('getAudiobooks', () => {
-    it('should fetch audiobooks successfully', async () => {
+    it('should fetch audiobooks successfully with default query', async () => {
       // Mock audiobooks response
       const mockAudiobooksData = {
         audiobooks: {
@@ -46,6 +46,42 @@ describe('SpotifyService', () => {
         market: 'AU',
         limit: 40,
         offset: 0
+      });
+      expect(audiobooksCall.headers).toEqual({
+        'Authorization': 'Bearer mock-token'
+      });
+    });
+    
+    it('should fetch audiobooks with custom search query', async () => {
+      // Mock audiobooks response
+      const mockAudiobooksData = {
+        audiobooks: {
+          items: [
+            { id: '3', name: 'Harry Potter' },
+            { id: '4', name: 'Harry Potter 2' }
+          ]
+        }
+      };
+
+      // Set up axios mock for the second call
+      axios.mockResolvedValueOnce({
+        data: mockAudiobooksData
+      });
+
+      const result = await spotifyService.getAudiobooks(20, 5, 'US', 'harry potter');
+      
+      expect(result).toEqual(mockAudiobooksData);
+      expect(axios).toHaveBeenCalledTimes(2);
+      
+      // Verify the search parameters
+      const audiobooksCall = axios.mock.calls[1][0];
+      expect(audiobooksCall.url).toBe('https://api.spotify.com/v1/search');
+      expect(audiobooksCall.params).toEqual({
+        q: 'harry potter',
+        type: 'audiobook',
+        market: 'US',
+        limit: 20,
+        offset: 5
       });
       expect(audiobooksCall.headers).toEqual({
         'Authorization': 'Bearer mock-token'


### PR DESCRIPTION
This PR implements the following changes:

1. Modified search to call Spotify API instead of local filtering
2. Added spinner/loading indicator during search
3. Added clear search button functionality
4. Updated unit tests for new search functionality
5. Implemented server-side search query support

The changes have been tested and work as expected.