### PR TITLE
GTM-2: Add multi-cast narrator support

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -13,7 +13,8 @@ const filteredAudiobooks = computed(() => {
   // Filter by multi-cast narrators if toggle is active
   if (multiCastOnly.value) {
     filtered = filtered.filter(audiobook => {
-      return audiobook.narrators && audiobook.narrators.length > 1;
+      if (!audiobook.narrators) return false;
+      return Array.isArray(audiobook.narrators) && audiobook.narrators.length > 1;
     });
   }
   
@@ -169,6 +170,18 @@ onMounted(() => {
   flex-direction: column;
   gap: 15px;
   align-items: flex-end;
+}
+
+@media (min-width: 768px) {
+  .search-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+  }
+  
+  .toggle-container {
+    margin-left: 20px;
+  }
 }
 
 .search-container {

--- a/client/src/views/__tests__/MulticastFilter.spec.ts
+++ b/client/src/views/__tests__/MulticastFilter.spec.ts
@@ -54,6 +54,22 @@ vi.mock('@/stores/spotify', () => {
       uri: '',
       total_chapters: 8,
       duration_ms: 2600000
+    },
+    { 
+      id: '4', 
+      name: 'Book with null narrators', 
+      authors: [{ name: 'Author 4' }], 
+      narrators: null, 
+      images: [], 
+      external_urls: { spotify: '' }, 
+      release_date: '', 
+      publisher: '', 
+      description: '',
+      media_type: '',
+      type: '',
+      uri: '',
+      total_chapters: 5,
+      duration_ms: 1800000
     }
   ];
   
@@ -84,9 +100,9 @@ describe('Multicast Filter', () => {
   it('should show all audiobooks when multicast filter is off', () => {
     const wrapper = mount(AudiobooksView)
     
-    // With filter off, should show all three books
+    // With filter off, should show all four books
     const audiobookCards = wrapper.findAll('[data-testid="audiobook-card"]')
-    expect(audiobookCards.length).toBe(3)
+    expect(audiobookCards.length).toBe(4)
   })
   
   it('should only show multi-narrator audiobooks when filter is on', async () => {

--- a/client/tests/multicast-filter.spec.ts
+++ b/client/tests/multicast-filter.spec.ts
@@ -15,8 +15,11 @@ test('MultiCast filter should show only multi-narrator audiobooks', async ({ pag
   const toggleCheckbox = page.locator('.toggle input[type="checkbox"]');
   await toggleCheckbox.check();
   
-  // Wait for results to update
-  await page.waitForTimeout(500); // Short wait for the UI to update
+  // Wait for results to update - this ensures the filtering has been applied
+  await page.waitForFunction(() => {
+    // This runs in the browser context
+    return document.querySelectorAll('.audiobook-card').length !== document.querySelectorAll('.audiobook-card[style*="display: none"]').length;
+  });
   
   // Get the filtered count
   const filteredCount = await page.locator('.audiobook-card').count();

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,36 @@
+## GTM-2: Add multi-cast narrator support
+
+**Link to issue:** [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)
+
+### Summary
+Implemented a toggle filter for multi-cast narrators that allows users to easily filter audiobooks with multiple narrators. The filter works in combination with the text search feature and persists during search operations.
+
+### Technical Notes
+- Added a toggle switch UI element next to the search bar
+- Modified the `filteredAudiobooks` computed property to filter based on narrator count
+- The toggle uses a smooth slider animation with a gradient background when active
+- Filter state is maintained when performing text searches
+
+### Tests Added
+- Added unit tests (4 tests) to verify multi-cast filter functionality
+- Added an e2e test for UI interaction verification
+
+### Human Testing Instructions
+1. Visit http://localhost:5173
+2. Toggle the "Multi-Cast Only" filter on
+3. Verify only audiobooks with multiple narrators are displayed
+4. Enter search text and verify filter stays active
+5. Clear search and verify filter remains active
+
+### Diagrams
+
+```mermaid
+flowchart TB
+    A[User Toggles Multi-Cast Filter] --> B{Is Filter On?}
+    B -- Yes --> C[Filter to Show Only Multi-Narrator Books]
+    B -- No --> D[Show All Books]
+    C --> E{Search Query Present?}
+    D --> E
+    E -- Yes --> F[Apply Search Filter to Current Results]
+    E -- No --> G[Display Current Results]
+```


### PR DESCRIPTION
## GTM-2: Add multi-cast narrator support

**Link to issue:** [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)

### Summary
Implemented a toggle filter for multi-cast narrators that allows users to easily filter audiobooks with multiple narrators. The filter works in combination with the text search feature and persists during search operations.

### Technical Notes
- Added a toggle switch UI element next to the search bar
- Modified the `filteredAudiobooks` computed property to filter based on narrator count
- The toggle uses a smooth slider animation with a gradient background when active
- Filter state is maintained when performing text searches

### Tests Added
- Added unit tests (4 tests) to verify multi-cast filter functionality
- Added an e2e test for UI interaction verification

### Human Testing Instructions
1. Visit http://localhost:5173
2. Toggle the "Multi-Cast Only" filter on
3. Verify only audiobooks with multiple narrators are displayed
4. Enter search text and verify filter stays active
5. Clear search and verify filter remains active

### Diagrams

```mermaid
flowchart TB
    A[User Toggles Multi-Cast Filter] --> B{Is Filter On?}
    B -- Yes --> C[Filter to Show Only Multi-Narrator Books]
    B -- No --> D[Show All Books]
    C --> E{Search Query Present?}
    D --> E
    E -- Yes --> F[Apply Search Filter to Current Results]
    E -- No --> G[Display Current Results]
```