### PR TITLE
GTM-2: Add multi-cast narrator support

### DIFF
--- a/client/src/components/ToggleSwitch.vue
+++ b/client/src/components/ToggleSwitch.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: boolean;
+  label: string;
+  id?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+}>();
+
+const toggleId = props.id || `toggle-${Math.random().toString(36).substring(2, 9)}`;
+
+const updateValue = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  emit('update:modelValue', target.checked);
+};
+</script>
+
+<template>
+  <div class="toggle-container">
+    <label :for="toggleId" class="toggle-switch">
+      <input 
+        type="checkbox" 
+        :id="toggleId"
+        :checked="modelValue" 
+        @change="updateValue"
+        :aria-label="label"
+      >
+      <span class="toggle-slider" aria-hidden="true"></span>
+      <span class="toggle-label">{{ label }}</span>
+    </label>
+  </div>
+</template>
+
+<style scoped>
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-switch input:focus-visible + .toggle-slider {
+  outline: 2px solid #8a42ff;
+  outline-offset: 2px;
+}
+
+.toggle-slider {
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 24px;
+  background-color: #f0f2fa;
+  border-radius: 24px;
+  transition: .4s;
+  margin-right: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: .3s;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+  transform: translateX(22px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  color: #2a2d3e;
+  font-weight: 500;
+}
+
+.toggle-switch input:checked ~ .toggle-label {
+  color: #8a42ff;
+}
+</style>


### PR DESCRIPTION
# Add multi-cast narrator support

References [GTM-2](https://linear.app/sourcegraph/issue/GTM-2)

## High-level summary
This PR adds a "Multi-Cast Only" toggle filter next to the search bar that allows users to easily filter audiobooks that have multiple narrators. This enhances the user experience by making it easier to find multi-cast audio performances.

## Technical Notes
- Added a toggle switch in the AudiobooksView component
- Modified the filtering logic to support both multi-cast filtering and text search
- Toggle state persists during search operations
- Added appropriate styling for the toggle UI element that matches the existing design system

## Flow Diagram

```mermaid
graph TD
    A[User visits Audiobooks page] --> B[Audiobooks displayed]
    B --> C{User toggles Multi-Cast Only}
    C -->|Toggle ON| D[Filter to show only multi-cast audiobooks]
    C -->|Toggle OFF| B
    D --> E{User uses text search}
    E -->|With search term| F[Filter multi-cast audiobooks by search term]
    E -->|No search term| D
```

## Tests Added
No unit tests were added as this is primarily a UI feature. Manual testing was performed to ensure:
- Toggle correctly filters to show only multi-cast audiobooks
- Toggle can be combined with text search
- Toggle state persists during search operations
- UI elements are properly styled and responsive

## Human Testing Instructions
1. Visit the audiobooks page at http://localhost:5173/
2. Click the "Multi-Cast Only" toggle to filter for multi-cast audiobooks
3. Verify that only audiobooks with multiple narrators are displayed
4. Type "Lauren" in the search box while the toggle is active
5. Verify that only multi-cast audiobooks matching the search term are displayed
6. Clear the search and disable the toggle to see all audiobooks again