### PR TITLE
Add multi-cast narrator support

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -13,7 +13,7 @@ const filteredAudiobooks = computed(() => {
   // Filter by multi-cast narrators if toggle is enabled
   if (multiCastOnly.value) {
     filtered = filtered.filter(audiobook => {
-      return audiobook.narrators && audiobook.narrators.length > 1;
+      return audiobook.narrators?.length > 1;
     });
   }
   
@@ -61,15 +61,20 @@ onMounted(() => {
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
         <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
-          <div class="toggle-container">
+          <div class="search-input-group">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
             <label class="toggle-switch">
-              <input type="checkbox" v-model="multiCastOnly">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                role="switch" 
+                :aria-checked="multiCastOnly.toString()"
+              >
               <span class="toggle-slider"></span>
               <span class="toggle-label">Multi-Cast Only</span>
             </label>
@@ -165,14 +170,19 @@ onMounted(() => {
 .search-container {
   position: relative;
   width: 100%;
-  max-width: 450px;
+  max-width: 550px;
+}
+
+.search-input-group {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  align-items: center;
+  gap: 15px;
+  flex-wrap: wrap;
 }
 
 .search-input {
-  width: 100%;
+  flex: 1;
+  min-width: 250px;
   padding: 12px 20px;
   border: none;
   border-radius: 30px;
@@ -187,11 +197,6 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
-}
-
-.toggle-container {
-  display: flex;
-  justify-content: flex-end;
 }
 
 .toggle-switch {


### PR DESCRIPTION
# Add multi-cast narrator support

Implements issue GTM-2: Add multi-cast narrator toggle filter

## Summary

This PR adds a toggle next to the search bar that allows users to filter audiobooks to show only those with multiple narrators. This enhancement enables users to easily find multi-cast audiobooks when they prefer performances with diverse voice actors.

## Technical Notes

- Added a new `multiCastOnly` ref boolean state in AudiobooksView.vue
- Updated the filteredAudiobooks computed property to incorporate the multi-cast filter logic
- Added toggle UI next to the search bar with appropriate styling
- Ensured the toggle works in combination with text search
- Toggle state persists during search operations

## Mermaid Diagram

```mermaid
flowchart TD
    A[User loads audiobooks page] --> B[All audiobooks displayed]
    B --> C{User toggles Multi-Cast Only?}
    C -->|Yes| D[Filter to show only multi-cast audiobooks]
    C -->|No| B
    D --> E{User enters search text?}
    E -->|Yes| F[Apply text search within multi-cast results]
    E -->|No| D
    B --> G{User enters search text?}
    G -->|Yes| H[Apply text search to all audiobooks]
    G -->|No| B
```

## Human Testing Instructions

1. Visit the audiobooks page at http://localhost:5173/
2. Toggle the "Multi-Cast Only" switch to ON
3. Verify that only audiobooks with multiple narrators are displayed
4. Type a search term (e.g., "lollapalooza") and verify search works within multi-cast filtered results
5. Clear the search and toggle the filter OFF
6. Verify all audiobooks are shown again

## Tests

Added 0 tests, removed 0 tests

This feature implementation was manually tested to ensure it meets all acceptance criteria.