### PR TITLE
GTM-2: Add release date to audiobook cards

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -74,6 +74,21 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+// Format release date to a readable format
+const formatReleaseDate = (dateStr: string) => {
+  if (!dateStr) return '';
+  
+  // Create a date object from the string
+  const date = new Date(dateStr);
+  
+  // Format the date to display as Month Day, Year
+  return date.toLocaleDateString('en-US', { 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric' 
+  });
+};
 </script>
 
 <template>
@@ -89,6 +104,9 @@ const formatNarrators = (narrators: any[]) => {
       </p>
       <p class="audiobook-narrator" v-if="audiobook.narrators && audiobook.narrators.length">
           <span class="label">Narrator:</span> {{ formatNarrators(audiobook.narrators) }}
+      </p>
+      <p class="audiobook-release-date" v-if="audiobook.release_date">
+          <span class="label">Released:</span> {{ formatReleaseDate(audiobook.release_date) }}
       </p>
       <p class="audiobook-details">
         <span>{{ formatDuration(audiobook.duration_ms) }}</span>
@@ -114,6 +132,7 @@ const formatNarrators = (narrators: any[]) => {
               <h2>{{ audiobook.name }}</h2>
               <p class="modal-authors">By {{ audiobook.authors.map(author => author.name).join(', ') }}</p>
               <p class="modal-publisher">Publisher: {{ audiobook.publisher }}</p>
+              <p class="modal-release-date" v-if="audiobook.release_date">Released: {{ formatReleaseDate(audiobook.release_date) }}</p>
               <p class="modal-details">
                 <span>{{ formatDuration(audiobook.duration_ms) }}</span>
               </p>
@@ -201,7 +220,7 @@ const formatNarrators = (narrators: any[]) => {
   text-overflow: ellipsis;
 }
 
-.audiobook-narrator {
+.audiobook-narrator, .audiobook-release-date {
   color: #8a8c99;
   margin: 0 0 10px;
   font-size: 13px;
@@ -350,7 +369,7 @@ const formatNarrators = (narrators: any[]) => {
   font-size: 16px;
 }
 
-.modal-publisher {
+.modal-publisher, .modal-release-date {
   color: #8a8c99;
   margin: 0 0 8px;
   font-size: 14px;


### PR DESCRIPTION
## GTM-2: Add Release Date to Audiobook Cards

### Summary for Product Manager
Implemented release date display in the audiobook cards and detail modals to give users information about when an audiobook was released. This enhances the user experience by providing more context about the audiobooks.

### Technical Notes
- Added `formatReleaseDate` function to format the date in a user-friendly way (Month Day, Year)
- Added release date display in both the audiobook card and detail modal
- Styled the release date to match existing design patterns
- Ensured the release date only appears if the data is available

### Diagram
```mermaid
flowchart TD
    A[Audiobook Data] -->|Contains release_date| B[Format Function]
    B -->|Formats YYYY-MM-DD to Month Day, Year| C[Display in UI]
    C -->|Shown in Card| D[Audiobook Card]
    C -->|Shown in Modal| E[Detail Modal]
```

### Tests Added
No additional tests were added as this was a UI enhancement using existing data structures.

### Human Testing Instructions
1. Visit the main page to see audiobooks
2. Verify release dates are shown on the audiobook cards
3. Click "View Details" to open a modal and verify the release date is shown there too
4. Verify the date format is user-friendly (e.g., "May 16, 2025" instead of "2025-05-16")