### PR TITLE
GTM-2: Add multi-cast narrator support

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,36 +5,48 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let results = spotifyStore.audiobooks;
+  
+  // Filter by search query if provided
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    results = results.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
+      }
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
+    });
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
-      }
-      return false;
+  // Filter by multi-cast if toggle is active
+  if (multiCastOnly.value) {
+    results = results.filter(audiobook => {
+      // Check if there are multiple narrators
+      return audiobook.narrators && audiobook.narrators.length > 1;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return results;
 });
 
 onMounted(() => {
@@ -48,13 +60,22 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filter-controls">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch">
+              <input type="checkbox" v-model="multiCastOnly">
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -143,6 +164,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filter-controls {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +192,64 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+/* Toggle Switch Styles */
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+  background-color: #ccc;
+  border-radius: 34px;
+  transition: 0.4s;
+  flex-shrink: 0;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: 0.4s;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+  transform: translateX(24px);
+}
+
+.toggle-label {
+  margin-left: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
## GTM-2: Add multi-cast narrator support

### Description
Added a "Multi-Cast Only" toggle that allows users to filter audiobooks to show only those with multiple narrators.

### Link to Issue
[GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)

### High-Level Summary for Product Manager
Implemented a new filter toggle that helps users quickly find audiobooks with multiple voice actors. This feature improves discovery of multi-cast performances which many users prefer for a more engaging listening experience.

### Technical Notes
- Added a toggle switch next to the search bar UI
- Implemented filtering logic in the computed property to filter audiobooks with multiple narrators
- Ensured the toggle state persists during search operations
- Made toggle styling match the existing design system
- Toggle can be combined with text search for more specific filtering

### Architecture Diagram

```mermaid
flowchart TD
    A[User Interface] -->|Toggle State| B("multiCastOnly ref")
    C[Search Query] -->|Text Input| D("searchQuery ref")
    B --> E{"filteredAudiobooks<br>computed property"}
    D --> E
    F["Audiobooks Array"] --> E
    E -->|"Filter by<br>search query"| G["Filter if query exists"]
    E -->|"Filter by<br>narrator count"| H["Filter if multiCastOnly=true"]
    G --> I["Final Filtered List"]
    H --> I
    I --> J["Rendered Audiobook Cards"]
```

### Test Information
**Added Tests**: 0 tests added (UI feature visible in browser)

### Human Testing Instructions
1. Visit the audiobooks page at http://localhost:5173/
2. Look for the "Multi-Cast Only" toggle next to the search box
3. Click the toggle to enable it - only audiobooks with multiple narrators should remain visible
4. Type a search term while the toggle is enabled - results should show audiobooks that both match the search AND have multiple narrators
5. Disable the toggle - all matching audiobooks should return

Implementation time: 20250520-0910