### PR TITLE
feat(GTM-2): Add multi-cast narrator filter toggle

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,36 +5,47 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let filtered = spotifyStore.audiobooks;
+  
+  // Filter by multi-cast narrator if toggle is enabled
+  if (multiCastOnly.value) {
+    filtered = filtered.filter(audiobook => {
+      return audiobook.narrators && audiobook.narrators.length > 1;
+    });
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    filtered = filtered.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return filtered;
 });
 
 onMounted(() => {
@@ -48,13 +59,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="multi-cast-toggle">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
         </div>
       </div>
       
@@ -67,7 +91,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks found.' 
+            : multiCastOnly && searchQuery.trim()
+            ? 'No multi-cast audiobooks match your search.'
+            : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -141,6 +171,68 @@ onMounted(() => {
   height: 4px;
   background: linear-gradient(90deg, #e942ff, #8a42ff);
   border-radius: 2px;
+}
+
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.multi-cast-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+}
+
+.toggle-checkbox {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 26px;
+  background: #e0e0e0;
+  border-radius: 13px;
+  transition: all 0.3s ease;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider::before {
+  transform: translateX(24px);
+}
+
+.toggle-text {
+  font-size: 16px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
 }
 
 .search-container {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support

**Resolves:** [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support) - Add multi-cast narrator support

## Summary

This PR implements a "Multi-Cast Only" toggle filter that allows users to easily find audiobooks with multiple narrators. The feature is designed for users who prefer performances with diverse voice actors.

## Product Manager Summary

- Added an intuitive toggle control next to the search bar for easy discovery
- Users can now quickly filter to show only multi-cast audiobooks (those with 2+ narrators)
- The filter integrates seamlessly with the existing search functionality
- Clear feedback is provided when no multi-cast audiobooks match the current criteria
- Enhanced user experience for discovering diverse voice performances

## Technical Notes

### Implementation Details

- **Frontend**: Added reactive toggle component using Vue 3.5 composition API
- **Filtering Logic**: Enhanced the computed `filteredAudiobooks` function to support dual filtering (search + multi-cast)
- **UI Components**: Custom toggle with gradient styling consistent with app design
- **State Management**: Toggle state is reactive and works with existing search functionality

### Changes Made

1. **Enhanced Filtering Logic** (`AudiobooksView.vue`):
   - Modified `filteredAudiobooks` computed property to support layered filtering
   - Added `multiCastOnly` reactive ref for toggle state
   - Filter checks `audiobook.narrators.length > 1` for multi-cast detection

2. **UI Components**:
   - Added toggle component with custom CSS styling
   - Implemented visual active state with gradient background
   - Added responsive layout with flex container for controls

3. **User Experience**:
   - Contextual feedback messages for different filter states
   - Toggle persists during search operations
   - Visual indication of active filter state

### Architecture Diagram

```mermaid
flowchart TD
    A[User toggles Multi-Cast Only] --> B[multiCastOnly ref updated]
    B --> C[filteredAudiobooks computed triggers]
    C --> D{multiCastOnly enabled?}
    D -->|Yes| E[Filter by narrators.length > 1]
    D -->|No| F[Show all audiobooks]
    E --> G{Search query exists?}
    F --> G
    G -->|Yes| H[Apply text search filter]
    G -->|No| I[Return filtered results]
    H --> I
    I --> J[Update UI with filtered audiobooks]
    
    K[User searches] --> L[searchQuery ref updated]
    L --> C
    
    style B fill:#e942ff
    style C fill:#8a42ff
    style J fill:#e942ff
```

## Testing

### Automated Tests
- All existing unit tests pass ✅
- Build process completes successfully ✅
- TypeScript compilation passes ✅

### Manual Testing Completed
- **Toggle functionality**: ✅ Correctly filters to show only multi-cast audiobooks
- **Search integration**: ✅ Works seamlessly with existing search
- **Edge cases**: ✅ Proper handling of empty results with contextual messages
- **Visual states**: ✅ Toggle shows active state with gradient background
- **Responsive design**: ✅ Layout adapts properly on different screen sizes

### New Tests Added
None - this feature enhances existing functionality without requiring new test infrastructure.

## Human Testing Instructions

1. **Visit the application**: Navigate to http://localhost:5173
2. **Verify toggle presence**: Confirm "Multi-Cast Only" toggle appears next to search bar
3. **Test basic filtering**:
   - Click the toggle ON → Should show only audiobooks with multiple narrators
   - Click the toggle OFF → Should show all audiobooks again
4. **Test search integration**:
   - Enable multi-cast toggle
   - Search for "Paradise" → Should show "The Paradise Problem" (Jon Root, Pattie Murin)
   - Clear search → Should show all multi-cast audiobooks
5. **Verify visual feedback**:
   - Toggle should show gradient background when active
   - Appropriate messages should appear when no results match criteria

## Screenshots

### All Audiobooks (Toggle Off)
Shows the complete collection including both single and multi-cast audiobooks.

### Multi-Cast Filtered (Toggle On)  
Shows only audiobooks with multiple narrators, demonstrating the filter working correctly.

## Acceptance Criteria Verification

✅ **A "Multi-Cast Only" toggle is displayed next to the search bar**  
✅ **When enabled, only audiobooks with more than one narrator are shown**  
✅ **Toggle state persists during search operations**  
✅ **Toggle can be combined with text search**  
✅ **Toggle shows visual indication of active state**  
✅ **User sees feedback when no multi-cast audiobooks match criteria**