### PR TITLE
Add multi-cast narrator support

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,36 +5,63 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
-const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+const hasMultipleNarrators = (audiobook: { narrators?: (string | { name?: string })[] }) => {
+  if (!audiobook.narrators || audiobook.narrators.length <= 1) {
+    return false;
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
+  // Check if there are unique narrator names
+  const narratorNames = new Set();
+  for (const narrator of audiobook.narrators) {
+    if (typeof narrator === 'string') {
+      narratorNames.add(narrator.toLowerCase().trim());
+    } else if (narrator && typeof narrator === 'object' && narrator.name) {
+      narratorNames.add(narrator.name.toLowerCase().trim());
     }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  }
+  
+  return narratorNames.size > 1;
+};
+
+const filteredAudiobooks = computed(() => {
+  let results = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    results = results.filter(audiobook => hasMultipleNarrators(audiobook));
+  }
+  
+  // Apply text search if there's a query
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    results = results.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return results;
 });
 
 onMounted(() => {
@@ -48,13 +75,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filters-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-input"
+              />
+              <span class="toggle-switch"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +107,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks found.' 
+            : multiCastOnly && searchQuery.trim()
+            ? 'No multi-cast audiobooks match your search criteria.'
+            : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +189,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filters-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +217,66 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 14px;
+  color: #8a8c99;
+  transition: color 0.3s ease;
+  gap: 10px;
+}
+
+.toggle-label.active {
+  color: #8a42ff;
+  font-weight: 600;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-switch {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #e0e2e7;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-switch::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-switch {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-switch::before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support

Fixes GTM-2

## Summary

This PR implements a toggle to filter audiobooks with multiple narrators, allowing users to easily find multi-cast audiobooks when they prefer performances with diverse voice actors.

## Product Manager Summary

Users can now toggle a "Multi-Cast Only" filter next to the search bar to see only audiobooks that have more than one narrator. This feature helps users who prefer audiobooks with multiple voice actors for different characters or varied storytelling. The toggle works seamlessly with the existing search functionality and provides clear feedback when no results match the criteria.

## Technical Notes

- Added `multiCastOnly` reactive variable to track toggle state
- Implemented `hasMultipleNarrators` function that checks for unique narrator names (handles both string and object narrator formats)
- Modified `filteredAudiobooks` computed property to apply multi-cast filter before text search
- Updated template with new toggle UI component next to search bar
- Enhanced no-results messaging to provide specific feedback for multi-cast filtering
- Added comprehensive CSS styling for toggle with visual active state indication

## Feature Diagram

```mermaid
flowchart TD
    A[User visits audiobooks page] --> B[Audiobooks load from API]
    B --> C{Multi-Cast toggle enabled?}
    C -->|Yes| D[Filter to audiobooks with >1 unique narrator]
    C -->|No| E[Show all audiobooks]
    D --> F{Search query entered?}
    E --> F
    F -->|Yes| G[Apply text search filter]
    F -->|No| H[Display filtered results]
    G --> H
    H --> I{Any results?}
    I -->|Yes| J[Show audiobook grid]
    I -->|No| K[Show contextual no-results message]
```

## Testing

**Unit Tests:** Type checking passes ✅

**Human Testing Instructions:**
1. Visit http://localhost:5173/
2. Observe the "Multi-Cast Only" toggle next to the search bar
3. Toggle the switch ON - should show purple gradient and only display audiobooks with multiple narrators
4. Toggle the switch OFF - should show all audiobooks again
5. With toggle ON, enter a search term - should filter multi-cast audiobooks by search criteria
6. Try combinations where no results match - should see contextual feedback message

**Expected Results:**
- Toggle shows visual indication when active (purple gradient)
- Only audiobooks with multiple unique narrators appear when toggle is ON
- Toggle state persists during search operations
- Search and toggle filters work together
- Appropriate feedback messages for different scenarios

## Acceptance Criteria Met

✅ 1. A "Multi-Cast Only" toggle is displayed next to the search bar  
✅ 2. When enabled, only audiobooks with more than one narrator are shown  
✅ 3. Toggle state persists during search operations  
✅ 4. Toggle can be combined with text search  
✅ 5. Toggle shows visual indication of active state  
✅ 6. User sees feedback when no multi-cast audiobooks match criteria

**Tests Added:** 0 tests added, 0 tests removed (existing tests maintained)