### PR TITLE
Add multi-cast narrator toggle filter - GTM-2

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,25 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks;
+  
+  // Filter by multi-cast narrators if toggle is enabled
+  if (multiCastOnly.value) {
+    books = books.filter(audiobook => {
+      return audiobook.narrators && audiobook.narrators.length > 1;
+    });
+  }
+  
+  // Apply search filter
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -48,13 +59,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="search-controls">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +91,9 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly ? 'No multi-cast audiobooks match your criteria.' : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +169,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.search-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +197,63 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 26px;
+  background-color: #ccc;
+  border-radius: 26px;
+  transition: background-color 0.3s;
+  margin-right: 12px;
+}
+
+.toggle-slider:before {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  top: 3px;
+  left: 3px;
+  background-color: white;
+  transition: transform 0.3s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider:before {
+  transform: translateX(24px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support

Fixes: [GTM-2 - Add multi-cast narrator support](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)

## Summary

This PR implements a toggle filter that allows users to display only audiobooks with multiple narrators (multi-cast audiobooks). The feature helps users easily find audiobooks with diverse voice actors when they prefer multi-cast performances.

## High-Level Changes for Product Manager

- **New Feature**: Added a "Multi-Cast Only" toggle filter next to the search bar
- **Enhanced Discovery**: Users can now easily find audiobooks with multiple narrators/voice actors
- **Improved UX**: Toggle works seamlessly with existing search functionality
- **Visual Feedback**: Clear indication when filter is active with gradient styling

## Technical Changes for Developers

### Frontend Changes
- Modified `client/src/views/AudiobooksView.vue`:
  - Added `multiCastOnly` reactive state variable
  - Enhanced `filteredAudiobooks` computed property to filter books with `narrators.length > 1`
  - Updated UI to include toggle switch component next to search bar
  - Implemented responsive layout for search controls container
  - Added custom toggle switch styling with gradient active state

### Key Implementation Details
- **Filtering Logic**: Checks `audiobook.narrators && audiobook.narrators.length > 1`
- **State Management**: Toggle state persists during search operations
- **Combined Filtering**: Multi-cast filter applies before text search, allowing both filters to work together
- **User Feedback**: Updated no-results message to indicate when no multi-cast books match criteria

## Feature Flow Diagram

```mermaid
flowchart TD
    A[User loads audiobook page] --> B[All audiobooks displayed]
    B --> C{Multi-Cast toggle clicked?}
    C -->|Yes| D[Filter to books with >1 narrator]
    C -->|No| E[Show all books]
    D --> F{Search text entered?}
    E --> F
    F -->|Yes| G[Apply text search to filtered results]
    F -->|No| H[Display current filtered/unfiltered results]
    G --> H
    H --> I[Show results with appropriate message]
```

## Testing Added

No automated tests added per requirements. Manual testing performed:

**Manual Testing Completed:**
- ✅ Toggle displays correctly next to search bar
- ✅ Clicking toggle filters to multi-cast audiobooks only
- ✅ Toggle visual state indicates active/inactive status
- ✅ Search functionality works with toggle enabled
- ✅ Combined search + toggle filtering works correctly
- ✅ Appropriate feedback message displays when no results found
- ✅ Toggle state persists during search operations

## Human Testing Instructions

Visit http://localhost:5173 and perform the following tests:

1. **Toggle Functionality**: Click the "Multi-Cast Only" toggle to filter audiobooks
   - Expected: Only audiobooks with multiple narrators should be displayed
   - Expected: Toggle should show active state with gradient background

2. **Combined Search**: With toggle enabled, search for "Rebecca" 
   - Expected: Should show only multi-cast audiobooks containing "Rebecca" in title/author/narrator
   - Expected: Should display 2 results (tested successfully)

3. **Toggle Off**: Disable toggle and verify all audiobooks return
   - Expected: Full list of audiobooks should be visible again

4. **No Results**: With toggle on, search for a term that won't match any multi-cast books
   - Expected: Should show "No multi-cast audiobooks match your criteria." message
