### PR TITLE
Add multi-cast narrator support - GTM-2

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,25 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks;
+  
+  // Filter by multi-cast narrator if toggle is enabled
+  if (multiCastOnly.value) {
+    books = books.filter(audiobook => {
+      return audiobook.narrators && audiobook.narrators.length > 1;
+    });
+  }
+  
+  // Apply search filter
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -48,13 +59,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="search-controls">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -143,6 +167,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.search-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +195,61 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-checkbox {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 12px;
+  transition: background 0.3s ease;
+}
+
+.toggle-slider:before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider:before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  color: #2a2d3e;
+  font-weight: 500;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support - GTM-2

## Product Summary
This PR implements a "Multi-Cast Only" toggle feature that allows users to filter audiobooks to show only those with multiple narrators. This helps users who prefer performances with diverse voice actors to easily find multi-cast audiobooks.

## Technical Notes
- Added a toggle button next to the search bar in the AudiobooksView component
- Implemented filtering logic to show only audiobooks with more than one narrator
- The toggle works in combination with existing search functionality
- Added responsive styling with gradient colors matching the app's design system
- The feature maintains state persistence during search operations

## Mermaid Diagram

```mermaid
flowchart TD
    A[User visits Audiobooks page] --> B[View search bar and toggle]
    B --> C{Toggle Multi-Cast Only?}
    C -->|No| D[Show all audiobooks]
    C -->|Yes| E[Filter to multi-narrator only]
    D --> F[Apply search filter if query exists]
    E --> F
    F --> G[Display filtered results]
    H[User searches] --> F
    I[User toggles multi-cast] --> C
```

## Testing Added
- No additional unit tests added (as per requirements)
- Feature tested visually on localhost:5173

## Human Testing Instructions
1. Visit http://localhost:5173
2. Navigate to the Audiobooks page (should be default)
3. Locate the "Multi-Cast Only" toggle next to the search bar
4. Toggle the switch to enable multi-cast filtering
5. Verify that only audiobooks with multiple narrators are displayed
6. Test search functionality while toggle is enabled to ensure it works in combination
7. Toggle off to show all audiobooks again

Expected behavior:
- Toggle shows visual indication when active (gradient purple styling)
- Only audiobooks with more than one narrator appear when enabled
- Search works in combination with the toggle
- Toggle state persists during search operations

Fixes: GTM-2
