### PR TITLE
Add multi-cast narrator support (GTM-2)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,40 +1,61 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
 
+// Multi-cast filter with localStorage persistence
+const multiCastOnly = ref(localStorage.getItem('multiCastFilter') === 'true');
+
+// Helper function to check if audiobook has multiple narrators
+const isMultiCast = (audiobook: any): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
+
+// Watch for multiCastOnly changes and persist to localStorage
+watch(multiCastOnly, (newValue) => {
+  localStorage.setItem('multiCastFilter', newValue.toString());
+});
+
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let result = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first if enabled
+  if (multiCastOnly.value) {
+    result = result.filter(isMultiCast);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply text search filter if query exists
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    result = result.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return result;
 });
 
 onMounted(() => {
@@ -48,13 +69,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filters-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -143,6 +177,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filters-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +205,66 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.3s ease;
+}
+
+.toggle-label.active .toggle-text {
+  color: #8a42ff;
+  font-weight: 600;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  margin-right: 10px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  color: #2a2d3e;
+  font-weight: 500;
+  transition: all 0.3s ease;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support (GTM-2)

## Summary
This PR implements a "Multi-Cast Only" toggle filter that allows users to filter audiobooks with multiple narrators. The feature includes localStorage persistence and seamlessly integrates with the existing search functionality.

## Technical Notes
- **Implementation**: Added reactive `multiCastOnly` ref with Vue 3 reactivity
- **Persistence**: Toggle state persists across browser sessions using localStorage
- **Filtering Logic**: Filters audiobooks where `narrators.length > 1`
- **UI Integration**: Added toggle component next to search bar with visual active state
- **Compatibility**: Works in combination with existing text search functionality

## Features Added
- Multi-cast narrator detection for both string and object narrator formats
- Responsive toggle UI with gradient styling and smooth transitions
- localStorage persistence for user preference
- Visual feedback with active state indication
- Combined filtering with text search

## Mermaid Diagram
```mermaid
graph TD
    A[User visits page] --> B[Load audiobooks]
    B --> C[Check localStorage for multiCastFilter]
    C --> D[Initialize toggle state]
    D --> E[Display all audiobooks OR multi-cast only]
    
    F[User clicks toggle] --> G[Update multiCastOnly ref]
    G --> H[Save to localStorage]
    H --> I[Trigger computed filteredAudiobooks]
    
    I --> J{multiCastOnly enabled?}
    J -->|Yes| K[Filter narrators.length > 1]
    J -->|No| L[Show all audiobooks]
    
    K --> M{Search query exists?}
    L --> M
    M -->|Yes| N[Apply text search filter]
    M -->|No| O[Display filtered results]
    N --> O
    
    P[User types in search] --> Q[Update searchQuery ref]
    Q --> I
```

## Testing Instructions
1. Visit http://localhost:5173
2. Verify toggle appears next to search bar
3. Click toggle to enable "Multi-Cast Only" filter
4. Confirm only audiobooks with multiple narrators are displayed
5. Test search functionality works with toggle enabled
6. Refresh page and verify toggle state persists
7. Disable toggle and verify all audiobooks are shown again

## Tests Added/Removed
- No unit tests added per request - visual testing only

## Screenshots
Screenshots demonstrate the working functionality showing:
- Toggle in default state with all audiobooks
- Toggle activated showing only multi-cast audiobooks  
- Combined search + multi-cast filter working together
