### PR TITLE
Add Multi-Cast Narrator Filter Toggle

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,40 +1,58 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(JSON.parse(localStorage.getItem('multiCastOnly') || 'false'));
+
+const isMultiCast = (audiobook: any): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let filtered = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    filtered = filtered.filter(isMultiCast);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    filtered = filtered.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return filtered;
+});
+
+// Persist toggle state to localStorage
+watch(multiCastOnly, (newValue) => {
+  localStorage.setItem('multiCastOnly', JSON.stringify(newValue));
 });
 
 onMounted(() => {
@@ -48,13 +66,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filters-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -143,6 +174,12 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filters-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +201,64 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch.active .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-switch.active .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
+}
+
+.toggle-switch.active .toggle-label {
+  color: #8a42ff;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Filter Toggle

## Overview
This PR implements Option 2 from the technical review in GTM-2, adding a persistent multi-cast narrator filter toggle next to the search bar. Users can now easily filter audiobooks to show only those with multiple narrators.

## High-Level Changes (Product Manager Summary)
- Added a "Multi-Cast Only" toggle next to the search bar that filters audiobooks to show only those with multiple narrators
- Toggle state persists across browser sessions using localStorage for better user experience  
- Combined filtering works seamlessly with existing text search functionality
- Visual feedback with gradient styling when toggle is active
- Enables users to easily discover multi-cast audiobooks with diverse voice actors

## Technical Notes (Developer Summary)
- Modified `AudiobooksView.vue` to add reactive `multiCastOnly` ref with localStorage persistence
- Updated `filteredAudiobooks` computed property to apply multi-cast filter (`narrators.length > 1`) before text search
- Added toggle UI component with custom CSS styling and active state indication
- Implemented `isMultiCast` helper function to handle both string and NarratorObject narrator formats
- Used Vue 3 `watch` to automatically persist toggle state to localStorage
- Combined filters work sequentially: multi-cast filter first, then text search filter

## How It Works (Mermaid Diagram)

```mermaid
flowchart TD
    A[User loads AudiobooksView] --> B[Load multiCastOnly from localStorage]
    B --> C[Fetch audiobooks from Spotify API]
    C --> D[Apply filters in computed property]
    
    D --> E{Multi-Cast Toggle Active?}
    E -->|Yes| F[Filter: narrators.length > 1]
    E -->|No| G[Keep all audiobooks]
    
    F --> H{Search query exists?}
    G --> H
    
    H -->|Yes| I[Apply text search filter]
    H -->|No| J[Display filtered results]
    I --> J
    
    K[User toggles Multi-Cast] --> L[Update reactive ref]
    L --> M[Save to localStorage]
    M --> D
    
    N[User types in search] --> O[Update search query]
    O --> D
    
    style F fill:#e942ff,color:white
    style I fill:#8a42ff,color:white
    style L fill:#e942ff,color:white
```

## Testing Added
- No automated tests added (as requested)
- Manual testing performed on localhost:5173 with screenshots

## Human Testing Instructions
1. Visit http://localhost:5173
2. Observe the "Multi-Cast Only" toggle next to the search bar
3. Click the toggle to activate it - it should turn purple/pink
4. Verify only audiobooks with multiple narrators are displayed
5. Test search functionality while toggle is active - should filter within multi-cast results
6. Refresh the page - toggle state should persist
7. Deactivate toggle - all audiobooks should be visible again

## Screenshots
- Before: All audiobooks visible with toggle in inactive state
- After: Only multi-cast audiobooks shown with purple active toggle
- Combined: Search "Sara" with toggle active shows only multi-cast results matching "Sara"

**Added 0 tests, removed 0 tests**

Links to Linear issue: GTM-2 (https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)
