### PR TITLE
Add multi-cast narrator filter toggle with localStorage persistence

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,40 +1,62 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
+import type { Audiobook } from '@/types/spotify';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
 
+// Multi-cast toggle with localStorage persistence
+const multiCastOnly = ref(localStorage.getItem('multiCastOnly') === 'true');
+
+// Helper function to detect multi-cast audiobooks
+const isMultiCast = (audiobook: Audiobook): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
+
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let result = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    result = result.filter(isMultiCast);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search query filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    result = result.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return result;
+});
+
+// Watch for changes in multiCastOnly and persist to localStorage
+watch(multiCastOnly, (newValue) => {
+  localStorage.setItem('multiCastOnly', newValue.toString());
 });
 
 onMounted(() => {
@@ -48,13 +70,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +102,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks found.' 
+            : multiCastOnly && searchQuery.trim()
+            ? 'No multi-cast audiobooks match your search.'
+            : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,9 +184,87 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+  padding: 8px 16px;
+  border-radius: 25px;
+  transition: all 0.3s ease;
+  background: #f0f2fa;
+  border: 2px solid transparent;
+}
+
+.toggle-label.active {
+  background: rgba(138, 66, 255, 0.1);
+  border-color: rgba(138, 66, 255, 0.3);
+}
+
+.toggle-checkbox {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider::before {
+  transform: translateX(20px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
+}
+
+.toggle-label.active .toggle-text {
+  color: #8a42ff;
+  font-weight: 600;
 }
 
 .search-input {


### PR DESCRIPTION
# Multi-Cast Narrator Filter Toggle Implementation

**Link to User Story:** [GTM-2 - Add multi-cast narrator support](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)

## High-Level Summary

Implemented a "Multi-Cast Only" toggle filter that allows users to filter audiobooks by narrator count. When enabled, only audiobooks with multiple narrators are displayed. The feature includes localStorage persistence to maintain user preferences across sessions.

## Technical Notes

### Implementation Details
- **Component:** Updated `client/src/views/AudiobooksView.vue`
- **Approach:** Implemented Option 2 from the technical review (Persistent Toggle with LocalStorage)
- **State Management:** Added `multiCastOnly` reactive ref with localStorage persistence
- **Filtering Logic:** Multi-cast detection via `narrators.length > 1` check
- **UI Integration:** Toggle positioned next to search bar with visual active state indication

### Key Features
1. **Multi-Cast Detection:** Helper function `isMultiCast()` identifies audiobooks with > 1 narrator
2. **Combined Filtering:** Works seamlessly with existing text search functionality
3. **State Persistence:** Uses localStorage to remember user preference across sessions
4. **Visual Feedback:** Toggle shows clear active/inactive states with color changes
5. **Smart Error Messages:** Context-aware "no results" messages for different filter states

### Filter Logic Flow
```typescript
// Apply multi-cast filter first
if (multiCastOnly.value) {
  result = result.filter(isMultiCast);
}

// Then apply search query filter
if (searchQuery.value.trim()) {
  result = result.filter(/* text search logic */);
}
```

## Feature Diagram

```mermaid
flowchart TD
    A[User Loads Page] --> B[Check localStorage for multiCastOnly preference]
    B --> C[Initialize Toggle State]
    C --> D[Display Audiobooks]
    
    D --> E{User Toggles Multi-Cast Filter?}
    E -->|Yes| F[Update multiCastOnly state]
    F --> G[Save to localStorage]
    G --> H[Re-filter audiobooks]
    H --> I[Update display]
    I --> D
    
    E -->|No| J{User Searches?}
    J -->|Yes| K[Apply text search filter]
    K --> L[Combine with multi-cast filter if active]
    L --> I
    J -->|No| D
    
    style F fill:#e942ff
    style G fill:#8a42ff
    style H fill:#e942ff
```

## Human Testing Instructions

1. **Visit** http://localhost:5173
2. **Verify** the "Multi-Cast Only" toggle is visible next to the search bar
3. **Toggle ON** - Should show only audiobooks with multiple narrators (e.g., "Keep Me" with "Kelli Tager, Will Watt")
4. **Toggle OFF** - Should show all audiobooks including single narrators (e.g., "The Good Daughter" with "Kumi Taguchi")
5. **Search Test** - With toggle ON, search "Christina" - should show only "The Paradise Problem" with multi-cast narrators
6. **Persistence Test** - Toggle ON, refresh page - toggle should remain ON
7. **Visual Test** - Toggle should show purple styling when active, gray when inactive

## Test Results
- ✅ Toggle functionality works correctly
- ✅ Multi-cast filtering logic accurate (counts narrators > 1)
- ✅ Combined with text search without conflicts  
- ✅ localStorage persistence maintains user preference
- ✅ Visual active state indication clear
- ✅ Smart error messages for different filter states

**Added 0 tests, removed 0 tests** - Feature tested manually per requirements

## Screenshots

Screenshots demonstrate:
1. Multi-cast toggle enabled showing only multi-narrator audiobooks
2. Toggle disabled showing all audiobooks
3. Combined search + multi-cast filter functionality
