### PR TITLE
Add multi-cast narrator toggle filter (GTM-2)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,43 +1,77 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
+import type { Audiobook } from '@/types/spotify';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
 
-const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+// Multi-cast toggle with localStorage persistence
+const multiCastOnly = ref(false);
+
+// Load multi-cast toggle state from localStorage
+const loadMultiCastState = () => {
+  const saved = localStorage.getItem('multiCastOnly');
+  if (saved !== null) {
+    multiCastOnly.value = JSON.parse(saved);
   }
-  
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+};
+
+// Save multi-cast toggle state to localStorage
+const saveMultiCastState = () => {
+  localStorage.setItem('multiCastOnly', JSON.stringify(multiCastOnly.value));
+};
+
+// Watch for changes to multiCastOnly and persist to localStorage
+watch(multiCastOnly, saveMultiCastState);
+
+// Helper function to check if audiobook has multiple narrators
+const isMultiCast = (audiobook: Audiobook): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
+
+const filteredAudiobooks = computed(() => {
+  let result = spotifyStore.audiobooks;
+
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    result = result.filter(isMultiCast);
+  }
+
+  // Apply text search filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    result = result.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+
+  return result;
 });
 
 onMounted(() => {
+  loadMultiCastState();
   spotifyStore.fetchAudiobooks();
 });
 </script>
@@ -48,13 +82,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +114,9 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery ? 'No multi-cast audiobooks found.' : 'No audiobooks match your search criteria.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +192,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +220,59 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 10px;
+  user-select: none;
+}
+
+.toggle-checkbox {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support Toggle

**Fixes:** [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support) - Add multi-cast narrator support

## Summary

Implements Option 2 from the technical review: a persistent multi-cast toggle with localStorage that allows users to filter audiobooks with multiple narrators. The toggle is placed next to the search bar and provides a seamless way to discover multi-cast audiobooks with diverse voice actors.

## Technical Notes

- **Implementation**: Option 2 - Persistent Toggle with localStorage
- **Component**: Enhanced `AudiobooksView.vue` with reactive multi-cast filtering
- **Persistence**: Toggle state persists across browser sessions via localStorage  
- **Filtering Logic**: Filters audiobooks where `narrators.length > 1`
- **Integration**: Combines seamlessly with existing text search functionality
- **UI Design**: Custom toggle component with gradient active state matching app theme

### Key Changes:
1. Added `multiCastOnly` reactive ref with localStorage persistence
2. Updated `filteredAudiobooks` computed to include multi-cast filtering logic
3. Enhanced search header layout with new toggle component
4. Improved error messaging for empty filter results
5. Added comprehensive CSS styling for toggle component

## Feature Workflow

```mermaid
flowchart TD
    A[User visits audiobook page] --> B[Load toggle state from localStorage]
    B --> C[Display all audiobooks by default]
    C --> D{User clicks Multi-Cast toggle?}
    D -->|Yes| E[Filter to show only multi-cast audiobooks]
    D -->|No| F{User searches text?}
    E --> G[Save toggle state to localStorage]
    G --> H{Text search active?}
    H -->|Yes| I[Apply both filters: multi-cast AND text search]
    H -->|No| J[Show only multi-cast audiobooks]
    F -->|Yes| K[Apply text search filter]
    F -->|No| L[Show all audiobooks]
    I --> M[Display filtered results]
    J --> M
    K --> N{Multi-cast toggle active?}
    N -->|Yes| I
    N -->|No| M
    L --> M
    M --> O[User sees results with appropriate messaging]
```

## Testing Added

- **Manual Testing**: Verified at http://localhost:5173
- **Scenarios Tested**:
  - Toggle functionality (on/off state)
  - localStorage persistence across page refreshes
  - Combined filtering (multi-cast + text search)
  - Visual indication of active state
  - Appropriate messaging for empty results

**Added 0 tests, removed 0 tests** - No unit tests per requirements

## Human Testing Instructions

1. **Visit**: http://localhost:5173
2. **Test Basic Toggle**: 
   - Click "Multi-Cast Only" toggle → Should show only audiobooks with multiple narrators
   - Toggle should turn purple/gradient when active
   - Click again → Should return to showing all audiobooks
3. **Test Persistence**:
   - Enable toggle → Refresh page → Toggle should remain active and filtering enabled
4. **Test Combined Search**:
   - Enable toggle → Type "Sara" in search → Should show "Keep Me" (Sara Cate, multi-cast)
   - Disable toggle → Type "Sara" → Should show all Sara-related audiobooks
5. **Expected Results**:
   - Multi-cast books show multiple narrators (e.g., "Kelli Tager, Will Watt")
   - Single narrator books are filtered out when toggle is active
   - Search and toggle work together seamlessly
