### PR TITLE
Add multi-cast narrator toggle filter with localStorage persistence

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,40 +1,61 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
 
+// Multi-cast toggle with localStorage persistence
+const multiCastOnly = ref(localStorage.getItem('multiCastOnly') === 'true');
+
+// Watch for changes and persist to localStorage
+watch(multiCastOnly, (newValue) => {
+  localStorage.setItem('multiCastOnly', newValue.toString());
+});
+
+// Helper function to check if audiobook has multiple narrators
+const isMultiCast = (audiobook: any): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
+
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let filtered = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    filtered = filtered.filter(audiobook => isMultiCast(audiobook));
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply text search filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    filtered = filtered.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return filtered;
 });
 
 onMounted(() => {
@@ -48,13 +69,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="toggle-container">
+            <label class="toggle-switch">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
         </div>
       </div>
       
@@ -67,7 +101,14 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks found.' 
+            : multiCastOnly && searchQuery.trim()
+            ? 'No multi-cast audiobooks match your search.'
+            : 'No audiobooks match your search.'
+          }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -141,6 +182,68 @@ onMounted(() => {
   height: 4px;
   background: linear-gradient(90deg, #e942ff, #8a42ff);
   border-radius: 2px;
+}
+
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 48px;
+  height: 24px;
+  background: #e0e0e0;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  top: 2px;
+  left: 2px;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(24px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
 }
 
 .search-container {


### PR DESCRIPTION
# Add Multi-Cast Narrator Toggle Filter

## Overview

Implements **Option 2** from [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support) technical review: Multi-cast narrator filter toggle with localStorage persistence.

## Product Manager Summary

This feature adds a "Multi-Cast Only" toggle next to the search bar that allows users to filter audiobooks to show only those with multiple narrators. This helps users easily discover multi-cast audiobooks when they prefer diverse voice actor performances. The toggle state persists across sessions and works seamlessly with the existing search functionality.

## Technical Notes

- **Implementation Approach**: Reactive Vue 3 component with computed filtering logic
- **State Management**: localStorage persistence for toggle state across sessions  
- **Filtering Logic**: Checks `audiobook.narrators.length > 1` for multi-cast detection
- **UI Integration**: Toggle component styled with gradient theme, positioned next to search input
- **Search Compatibility**: Filter combines with existing text search functionality
- **Error Handling**: Contextual feedback messages for empty result sets

## How It Works

```mermaid
flowchart TD
    A[User toggles Multi-Cast Only] --> B[Update multiCastOnly reactive state]
    B --> C[Save state to localStorage]
    B --> D[filteredAudiobooks computed triggers]
    D --> E{multiCastOnly enabled?}
    E -->|Yes| F[Filter: narrators.length > 1]
    E -->|No| G[Show all audiobooks]
    F --> H{Search query exists?}
    G --> H
    H -->|Yes| I[Apply text search filter]
    H -->|No| J[Return filtered results]
    I --> J
    J --> K[Update UI with results]
```

## Testing

### Added 0 tests, removed 0 tests
No unit tests added per requirements - visual testing performed locally.

### Human Testing Instructions
1. Visit http://localhost:5173
2. **Toggle OFF**: Verify all audiobooks are displayed (multi-cast and single narrator)
3. **Toggle ON**: Click "Multi-Cast Only" toggle - should show purple gradient and filter to only books with 2+ narrators
4. **Search + Toggle**: With toggle ON, search for "sara" - should show "Keep Me" by Sara Cate (2 narrators)
5. **Persistence**: Refresh page - toggle state should persist
6. **No Results**: Search for non-existent term with toggle ON - should show "No multi-cast audiobooks match your search"

## Acceptance Criteria ✅

- ✅ **Multi-Cast Only toggle displayed next to search bar**
- ✅ **Only audiobooks with more than one narrator shown when enabled**
- ✅ **Toggle state persists during search operations**
- ✅ **Toggle combines with text search**
- ✅ **Toggle shows visual indication of active state** (purple gradient)
- ✅ **User sees feedback when no multi-cast audiobooks match criteria**

## Screenshots

### Toggle OFF (All Audiobooks)
Shows mix of single and multi-narrator audiobooks

### Toggle ON (Multi-Cast Only)
Shows only audiobooks with 2+ narrators, purple gradient indicates active state

### Combined Search + Filter
Search "sara" with toggle ON shows "Keep Me" by Sara Cate (2 narrators)
