### PR TITLE
Add multi-cast narrator support toggle

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,26 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
 
 const filteredAudiobooks = computed(() => {
+  let filtered = spotifyStore.audiobooks;
+  
+  // Filter by multi-cast if enabled
+  if (multiCastOnly.value) {
+    filtered = filtered.filter(audiobook => {
+      const narratorCount = audiobook.narrators?.length || 0;
+      return narratorCount > 1;
+    });
+  }
+  
+  // Filter by search query
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return filtered;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return filtered.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -48,13 +60,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="multi-cast-toggle">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
         </div>
       </div>
       
@@ -141,6 +166,67 @@ onMounted(() => {
   height: 4px;
   background: linear-gradient(90deg, #e942ff, #8a42ff);
   border-radius: 2px;
+}
+
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.multi-cast-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-checkbox {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
 }
 
 .search-container {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support Toggle

## Overview
This PR implements a toggle feature that allows users to filter audiobooks to show only those with multiple narrators, addressing the need for users who prefer multi-cast performances with diverse voice actors.

## Changes Made
- **New Toggle Component**: Added a "Multi-Cast Only" toggle button positioned next to the search bar
- **Filtering Logic**: Implemented filtering that checks if audiobooks have more than one narrator (narrators.length > 1)
- **Visual Design**: Created an animated toggle with purple gradient styling matching the app's design language
- **State Management**: Toggle state is reactive and works seamlessly with existing search functionality
- **User Experience**: Toggle provides immediate visual feedback and updates results instantly

## Technical Notes
- Updated the `filteredAudiobooks` computed property to support dual filtering (search + multi-cast)
- Added new reactive ref `multiCastOnly` to track toggle state
- Enhanced template with new controls container for better layout organization
- Implemented custom CSS toggle component with smooth animations and brand-consistent styling
- Filter operates before search filtering to maintain performance with large datasets

## Feature Workflow

```mermaid
flowchart TD
    A[User visits audiobooks page] --> B[All audiobooks displayed]
    B --> C{Toggle Multi-Cast Only?}
    C -->|No| D[Show all audiobooks]
    C -->|Yes| E[Filter to multi-cast only]
    D --> F{Search query entered?}
    E --> F
    F -->|No| G[Display filtered results]
    F -->|Yes| H[Apply search to filtered results]
    H --> G
    G --> I[User can toggle on/off anytime]
    I --> C
```

## Testing Added/Removed
- **Added**: 0 tests (visual verification only as requested)
- **Removed**: 0 tests

## Human Testing Instructions
1. Visit http://localhost:5173
2. Observe the "Multi-Cast Only" toggle next to the search bar
3. Click the toggle to enable it - expect to see:
   - Toggle slider moves right and turns purple
   - Only audiobooks with multiple narrators are displayed
   - Results count decreases significantly
4. Try searching while toggle is active - expect both filters to work together
5. Click toggle again to disable - expect all audiobooks to show again
6. Test toggle with various search terms to ensure compatibility

**Expected Results**: 
- When enabled: Only multi-cast audiobooks visible (e.g., "Keep Me" with "Kelli Tager, Will Watt")
- When disabled: All audiobooks visible including single-narrator ones
- Smooth animations and instant filtering responses

Resolves [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)
