### PR TITLE
feat: Add multi-cast narrator support with localStorage persistence

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -6,35 +6,57 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
 
+// Multi-cast toggle with localStorage persistence
+const multiCastOnly = ref(localStorage.getItem('multiCastOnly') === 'true' || false);
+
+// Helper function to determine if audiobook has multiple narrators
+const isMultiCast = (audiobook: any): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
+
+// Watch for toggle changes and persist to localStorage
+const toggleMultiCast = () => {
+  multiCastOnly.value = !multiCastOnly.value;
+  localStorage.setItem('multiCastOnly', multiCastOnly.value.toString());
+};
+
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let filtered = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    filtered = filtered.filter(isMultiCast);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter if there's a query
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    filtered = filtered.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return filtered;
 });
 
 onMounted(() => {
@@ -48,13 +70,27 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                :checked="multiCastOnly" 
+                @change="toggleMultiCast"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +103,9 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly ? 'No multi-cast audiobooks match your criteria.' : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +181,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +209,78 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+  padding: 8px 16px;
+  border-radius: 25px;
+  background: #f0f2fa;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.toggle-switch.active {
+  background: linear-gradient(90deg, rgba(233, 66, 255, 0.1), rgba(138, 66, 255, 0.1));
+  box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
+}
+
+.toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #ccc;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(20px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
+}
+
+.toggle-switch.active .toggle-label {
+  color: #8a42ff;
+  font-weight: 600;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support

## Overview
This PR implements Option 2 from the technical review for Linear issue GTM-2, adding a multi-cast narrator filter toggle with localStorage persistence. Users can now easily filter audiobooks to show only those with multiple narrators.

## User Story
- **As a user** I want a toggle to filter audiobooks with multiple narrators
- **So that** I can easily find multi-cast audiobooks when I prefer performances with diverse voice actors

## Changes Made

### Frontend Implementation
- **Multi-cast toggle component**: Added toggle switch next to search bar with visual active state
- **localStorage persistence**: Toggle state persists across browser sessions
- **Combined filtering**: Multi-cast filter works alongside existing text search functionality
- **Enhanced UI feedback**: Custom no-results message for multi-cast filtering scenarios
- **Responsive design**: Toggle adapts to different screen sizes with proper flex layout

### Technical Notes
- **Filter Logic**: Detects audiobooks with `narrators.length > 1` supporting both string and object narrator formats
- **State Management**: Uses Vue 3 reactive refs with localStorage synchronization
- **CSS Styling**: Custom toggle with gradient styling matching the app's design system
- **Performance**: Efficient computed property filtering with no additional API calls

## Feature Architecture

```mermaid
graph TD
    A[User visits page] --> B[Load localStorage state]
    B --> C[Initialize toggle from storage]
    C --> D[Display audiobooks list]
    
    D --> E[User toggles multi-cast filter]
    E --> F[Update reactive state]
    F --> G[Save to localStorage]
    F --> H[Filter audiobooks array]
    
    H --> I[Apply multi-cast filter]
    I --> J[Apply search filter if active]
    J --> K[Display filtered results]
    
    D --> L[User searches]
    L --> M[Combine with multi-cast filter]
    M --> K
    
    K --> N[Show appropriate no-results message]
```

## Testing Added
No unit tests were added per requirement, but comprehensive manual testing was performed.

## Human Testing Instructions
1. Visit http://localhost:5174/
2. Observe the "Multi-Cast Only" toggle next to the search bar
3. **Test toggle functionality**:
   - Click toggle to activate - should show only audiobooks with multiple narrators
   - Click again to deactivate - should show all audiobooks
4. **Test search combination**:
   - Activate toggle and search for "christina" - should show only multi-cast audiobooks matching search
   - Clear search with toggle active - should show all multi-cast audiobooks
5. **Test persistence**:
   - Activate toggle and refresh page - toggle should remain active
   - Verify audiobooks are still filtered after refresh

## Visual Verification

### Screenshots Included
- Multi-cast toggle in inactive state with all audiobooks
- Multi-cast toggle in active state showing only multi-cast audiobooks  
- Combined search and multi-cast filtering
- State persistence after page refresh

## Acceptance Criteria ✅
- [x] A "Multi-Cast Only" toggle is displayed next to the search bar
- [x] When enabled, only audiobooks with more than one narrator are shown
- [x] Toggle state persists during search operations
- [x] Toggle can be combined with text search
- [x] Toggle shows visual indication of active state
- [x] User sees feedback when no multi-cast audiobooks match criteria

## Related Issues
- Resolves GTM-2 - Add multi-cast narrator support
- Implements Option 2 from technical review (localStorage persistence)
