### PR TITLE
feat: add multi-cast narrator filter (GTM-2)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -2,39 +2,54 @@
 import { onMounted, ref, computed } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
+import type { Audiobook } from '@/types/spotify';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
+
+// Helper function to check if audiobook has multiple narrators
+const isMultiCastAudiobook = (audiobook: Audiobook): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let result = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first if enabled
+  if (multiCastOnly.value) {
+    result = result.filter(isMultiCastAudiobook);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter if query exists
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    result = result.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return result;
 });
 
 onMounted(() => {
@@ -48,13 +63,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filters-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly" 
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +95,11 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          <span v-if="multiCastOnly && !searchQuery.trim()">No multi-cast audiobooks found.</span>
+          <span v-else-if="multiCastOnly && searchQuery.trim()">No multi-cast audiobooks match your search.</span>
+          <span v-else>No audiobooks match your search.</span>
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,9 +175,21 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filters-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
 }
 
 .search-input {
@@ -166,6 +210,55 @@ onMounted(() => {
   background: #ffffff;
 }
 
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+}
+
 .audiobook-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -176,6 +269,24 @@ onMounted(() => {
 @media (min-width: 1200px) {
   .audiobook-grid {
     grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .audiobooks-header {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+  
+  .filters-container {
+    justify-content: center;
+    width: 100%;
+  }
+  
+  .search-container {
+    width: 100%;
+    max-width: 400px;
   }
 }
 


### PR DESCRIPTION
# Add Multi-Cast Narrator Support (GTM-2)

## Overview
Implements a toggle filter to help users discover audiobooks with multiple narrators, enabling easy access to multi-cast performances with diverse voice actors.

## Changes Made
- **Multi-Cast Only Toggle**: Added next to search bar with visual active state indication
- **Separate Filter Function**: Created `isMultiCastAudiobook()` helper following Option 2 from technical review
- **Composed Filtering**: Uses array chaining to combine search and multi-cast filters
- **Enhanced UX**: Appropriate feedback messages for different no-results scenarios
- **Responsive Design**: Mobile-friendly layout for filters container

## Technical Implementation
The implementation follows **Option 2** from the technical review, providing clean separation of concerns:

```typescript
// Helper function for reusability and testability
const isMultiCastAudiobook = (audiobook: Audiobook): boolean => {
  return audiobook.narrators && audiobook.narrators.length > 1;
};

// Composed filtering with array chaining
let result = spotifyStore.audiobooks;
if (multiCastOnly.value) {
  result = result.filter(isMultiCastAudiobook);
}
if (searchQuery.value.trim()) {
  result = result.filter(/* search logic */);
}
```

## Architecture Diagram

```mermaid
graph TD
    A[User Input] --> B{Multi-Cast Toggle}
    A --> C{Search Query}
    
    B -->|Enabled| D[isMultiCastAudiobook Filter]
    B -->|Disabled| E[All Audiobooks]
    
    C -->|Has Query| F[Search Filter]
    C -->|Empty| G[No Search Filter]
    
    D --> H[Apply Search Filter]
    E --> H
    
    H --> F
    H --> G
    
    F --> I[Combined Results]
    G --> I
    
    I --> J[Display Results]
    
    K[Narrator Data] --> L{Data Type}
    L -->|String| M[Single Narrator]
    L -->|Object| N[Narrator Object]
    L -->|Array Length > 1| O[Multi-Cast]
    
    O --> D
    M --> P[Not Multi-Cast]
    N --> Q{Array Length}
    Q -->|> 1| O
    Q -->|= 1| P
```

## Features Implemented
✅ Multi-Cast Only toggle displayed next to search bar  
✅ Only audiobooks with multiple narrators shown when enabled  
✅ Toggle state persists during search operations  
✅ Toggle combines with text search functionality  
✅ Visual indication of active toggle state  
✅ Appropriate feedback when no multi-cast audiobooks match criteria  
✅ Handles both string and object narrator data types  
✅ Responsive design for mobile devices  

## Testing Summary
- **Added 0 tests, removed 0 tests**: No unit tests required per user request
- **Manual Testing**: Verified all functionality works correctly at http://localhost:5173
- **Filter Verification**: Confirmed multi-cast filtering shows only books with multiple narrators
- **Search Combination**: Verified search + multi-cast filter combination works properly
- **Error States**: Confirmed appropriate messages for no-results scenarios

## Human Testing Instructions
1. Visit http://localhost:5173
2. **Test Multi-Cast Filter**: 
   - Toggle "Multi-Cast Only" - should show only books with multiple narrators
   - Example results: "Offside" (Stella Bloom, Gabriel Spires), "The Paradise Problem" (Jon Root, Pattie Murin)
3. **Test Search Combination**: 
   - Keep toggle enabled, search "paradise" - should show only "The Paradise Problem"
4. **Test No Results**: 
   - Keep toggle enabled, search "invisible" - should show "No multi-cast audiobooks match your search"
5. **Test Toggle Off**: 
   - Disable toggle - should show all audiobooks again

## Screenshots
Three test scenarios documented:
- Multi-cast filter disabled (all audiobooks)
- Multi-cast filter enabled (filtered results)  
- Multi-cast filter + search combination with no results

Linear Issue: https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support
