### PR TITLE
Add Multi-Cast Narrator Support (GTM-2)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,36 +5,53 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
+
+// Option 2: Separate Multi-Cast Filter Function (RECOMMENDED)
+const isMultiCastAudiobook = (audiobook: any) => {
+  if (!audiobook.narrators || !Array.isArray(audiobook.narrators)) {
+    return false;
+  }
+  return audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let results = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first if enabled
+  if (multiCastOnly.value) {
+    results = results.filter(isMultiCastAudiobook);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter if query exists
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    results = results.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return results;
 });
 
 onMounted(() => {
@@ -48,13 +65,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +97,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks available.' 
+            : multiCastOnly 
+              ? 'No multi-cast audiobooks match your search.' 
+              : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +179,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +207,61 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #e0e4ed;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support (GTM-2)

## Summary

Implements Option 2 from the technical review to add multi-cast narrator filtering functionality. Users can now filter audiobooks to only show those with multiple narrators using a toggle next to the search bar.

## Technical Implementation

Following the recommended **Option 2: Separate Multi-Cast Filter Function** approach:

- Created dedicated `isMultiCastAudiobook()` helper function for clean separation of concerns
- Implemented toggle component with visual state indication  
- Extended `filteredAudiobooks` computed property to compose multiple filters
- Added support for combined search and multi-cast filtering
- Handles edge cases for narrator data types (string vs object)

## Technical Notes

The implementation uses array chaining to compose filters, making it easily extensible for future filter additions. The multi-cast filter is applied first, followed by text search filtering, ensuring optimal performance and predictable behavior.

Key technical decisions:
- Separate filter function for reusability and testability
- Reactive state management for toggle persistence during searches
- Graceful handling of missing or malformed narrator data
- Clean CSS styling with gradient toggle states matching app theme

## Feature Flow

```mermaid
flowchart TD
    A[User visits audiobooks page] --> B[All audiobooks displayed]
    B --> C{Multi-Cast toggle clicked?}
    C -->|Yes| D[Filter to multi-cast only]
    C -->|No| E{Search query entered?}
    D --> F{Search query entered?}
    F -->|Yes| G[Apply search to multi-cast results]
    F -->|No| H[Show multi-cast audiobooks only]
    E -->|Yes| I[Apply search to all audiobooks]
    E -->|No| B
    G --> J[Display filtered results]
    H --> J
    I --> J
    J --> K{Toggle state changed?}
    K -->|Yes| C
    K -->|No| L{Search query changed?}
    L -->|Yes| M[Re-apply current filters]
    L -->|No| J
    M --> J
```

## Testing

### Functional Tests Completed:
- ✅ Toggle displays correctly next to search bar
- ✅ Multi-cast filtering works (shows only audiobooks with multiple narrators)
- ✅ Combined search + multi-cast filtering works correctly
- ✅ Toggle state persists during search operations
- ✅ Appropriate feedback messages for different filter states
- ✅ Visual state indication for active/inactive toggle

### Human Testing Instructions:
1. Visit http://localhost:5173
2. Verify toggle appears next to search bar
3. Click "Multi-Cast Only" toggle - should show only 2 audiobooks (Offside, The Paradise Problem)
4. Type "paradise" in search while toggle is on - should show only "The Paradise Problem"
5. Turn off toggle - should still show "The Paradise Problem" (search persisted)
6. Clear search - should show all audiobooks again

## Changes Made
- **Added**: Multi-cast filter toggle component with visual styling
- **Added**: `isMultiCastAudiobook()` helper function  
- **Modified**: `filteredAudiobooks` computed property to support multi-cast filtering
- **Added**: Dynamic "no results" messages based on filter state
- **Added**: CSS styling for toggle component with brand-consistent gradients

**Tests Added**: 0 tests (visual testing only as requested)  
**Tests Removed**: 0 tests

## References
- Linear Issue: [GTM-2](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support)
- Implementation follows Option 2 from technical review in issue comments
