### PR TITLE
Fix SonarQube issue AZhyh5RwQkXnhmx4R6NJ: Remove this unused import of 'vi'.

### DIFF
--- a/client/src/components/__tests__/AudiobookCard.spec.ts
+++ b/client/src/components/__tests__/AudiobookCard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AudiobookCard from '../AudiobookCard.vue'
 


### PR DESCRIPTION
## Fix SonarQube Issue: Remove Unused Import

### Issue Details
- **SonarQube Issue Key**: AZhyh5RwQkXnhmx4R6NJ
- **Rule**: typescript:S1128 - "Unnecessary imports should be removed"
- **Severity**: MINOR
- **Type**: CODE_SMELL
- **Language**: TypeScript
- **Impact**: MAINTAINABILITY (LOW)

### File and Location
- **File**: `client/src/components/__tests__/AudiobookCard.spec.ts`
- **Line**: 1
- **Component**: Isuru-F_demo-latest-audiobooks:client/src/components/__tests__/AudiobookCard.spec.ts

### What Was Wrong
The test file was importing `vi` from 'vitest' but never using it anywhere in the code. According to SonarQube rule S1128, unnecessary imports should be removed as they:
- Add extra weight to the JavaScript bundle
- Lead to potential performance issues
- Create maintainability issues
- Don't contribute to the functionality of the application

### How It Was Fixed
Removed the unused `vi` import from the vitest import statement on line 1:

**Before:**
```typescript
import { describe, it, expect, vi } from 'vitest'
```

**After:**
```typescript
import { describe, it, expect } from 'vitest'
```

### Testing Done
- Ran unit tests for the AudiobookCard component: `npm run test:unit -- --run src/components/__tests__/AudiobookCard.spec.ts`
- All 2 tests passed successfully
- No functionality was affected by removing the unused import

### Additional Notes
- The fix follows SonarQube's recommendation to regularly review and remove unused imports
- Modern JavaScript build tools can use tree shaking to eliminate unused code, but removing it at the source is a better practice
- No other imports or functionality were affected by this change
