### PR TITLE
Fix SonarQube issue AZhyh5R5QkXnhmx4R6NK: Use <img> instead of the img role to ensure accessibility across all devices.

### DIFF
--- a/client/src/components/icons/IconTooling.vue
+++ b/client/src/components/icons/IconTooling.vue
@@ -4,7 +4,6 @@
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     aria-hidden="true"
-    role="img"
     class="iconify iconify--mdi"
     width="24"
     height="24"


### PR DESCRIPTION
# Fix SonarQube Issue AZhyh5R5QkXnhmx4R6NK: Remove Redundant ARIA Role

## Summary
This PR fixes a SonarQube accessibility issue by removing a redundant ARIA role from an SVG element in the IconTooling component.

## SonarQube Issue Details
- **Issue Key**: AZhyh5R5QkXnhmx4R6NK
- **Rule**: Web:S6819 - "Prefer tag over ARIA role"
- **Severity**: MAJOR
- **Message**: Use &lt;img&gt; instead of the img role to ensure accessibility across all devices
- **File**: `client/src/components/icons/IconTooling.vue`
- **Line**: 7

## What Was Wrong
The SVG element in the IconTooling component had a redundant `role="img"` attribute. Since SVG elements are already semantically appropriate for displaying graphics and have built-in accessibility features, the ARIA role was unnecessary and actually goes against accessibility best practices.

## How It Was Fixed
Removed the `role="img"` attribute from the SVG element while keeping all other attributes intact, including:
- `aria-hidden="true"` for proper accessibility
- All styling and display attributes
- Namespace declarations

## Technical Notes
- The fix aligns with W3C accessibility guidelines that recommend using semantic HTML elements over ARIA roles when possible
- SVG elements have inherent behaviors and universal support by browsers and assistive technologies
- The `aria-hidden="true"` attribute is retained as it's appropriate for decorative icons

## Testing
- Verified the component still renders correctly after the change
- Ran unit tests to ensure no functionality was broken
- Built the client application successfully

## Code Changes
```diff
  <svg
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    aria-hidden="true"
-   role="img"
    class="iconify iconify--mdi"
    width="24"
    height="24"
    preserveAspectRatio="xMidYMid meet"
    viewBox="0 0 24 24"
  >
```

## Human Testing Instructions
1. Navigate to any page that displays the tooling icon
2. Verify the icon renders correctly without any visual changes
3. Use screen reader or accessibility tools to confirm proper accessibility behavior
4. Expected: Icon should be properly hidden from screen readers due to `aria-hidden="true"`

## Tests Added/Removed
- No new tests added (existing tests cover component rendering)
- 0 tests removed
- Verified existing unit tests continue to pass
