### PR TITLE
Add Multi-Cast Narrator Filter Toggle (GTM-2 Option 2)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -2,39 +2,57 @@
 import { onMounted, ref, computed } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
+import type { Audiobook } from '@/types/spotify';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
+
+// Helper function to check if an audiobook has multiple narrators
+const isMultiCastAudiobook = (audiobook: Audiobook): boolean => {
+  if (!audiobook.narrators || audiobook.narrators.length === 0) {
+    return false;
+  }
+  return audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let result = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    result = result.filter(isMultiCastAudiobook);
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    result = result.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return result;
 });
 
 onMounted(() => {
@@ -48,13 +66,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch" :class="{ active: multiCastOnly }">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +98,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+            ? 'No multi-cast audiobooks found.' 
+            : multiCastOnly && searchQuery.trim()
+            ? 'No multi-cast audiobooks match your search.'
+            : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +180,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +208,67 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.3s ease;
+}
+
+.toggle-switch.active .toggle-label {
+  color: #8a42ff;
+  font-weight: 600;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 24px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  color: #666;
+  font-weight: 500;
+  transition: all 0.3s ease;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Filter Toggle

Implements Option 2 from [GTM-2 technical review](https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support) - separate multi-cast filter function approach.

## High-Level Summary for Product Manager

This feature adds a "Multi-Cast Only" toggle next to the search bar that allows users to filter audiobooks to show only those with multiple narrators. The toggle works independently and can be combined with text search. When enabled, it provides users with an easy way to discover audiobooks featuring diverse voice actors and multi-cast performances.

## Technical Notes for Developer

### Implementation Details

- **Helper Function**: Created `isMultiCastAudiobook(audiobook: Audiobook)` that checks if `audiobook.narrators.length > 1`
- **Filter Logic**: Extended `filteredAudiobooks` computed property with array chaining pattern
- **UI Component**: Added toggle switch with visual styling next to search input
- **State Management**: Added `multiCastOnly` reactive ref for toggle state
- **Error Handling**: Enhanced no-results messaging for different filter combinations

### Architecture

```mermaid
graph LR
    A[Raw Audiobooks] --> B[Multi-Cast Filter]
    B --> C[Search Filter]
    C --> D[Filtered Results]
    
    E[Toggle State] --> B
    F[Search Query] --> C
    
    B --> G{isMultiCastAudiobook()}
    G --> H[Check narrators.length > 1]
```

The implementation follows the clean separation of concerns pattern by:
1. Creating a dedicated, reusable filter function
2. Applying filters in logical sequence (multi-cast first, then search)
3. Maintaining existing search functionality without disruption

## Testing

### Unit Tests Added/Removed
- No unit tests added per requirements - visual verification only

### Human Testing Instructions

1. **Visit** http://localhost:5173/
2. **Verify** the "Multi-Cast Only" toggle appears next to the search bar
3. **Test Toggle Off (Default State)**:
   - All audiobooks should be visible
   - Toggle should appear gray/inactive
4. **Test Toggle On**:
   - Click the toggle
   - Toggle should turn purple/active
   - Only audiobooks with multiple narrators should display (e.g., "Offside: Rules of the Game" with "Stella Bloom, Gabriel Spires")
5. **Test Combined Filtering**:
   - Keep toggle enabled
   - Search for "paradise"
   - Should show "The Paradise Problem" (has multiple narrators: "Jon Root, Pattie Murin")
6. **Test Error States**:
   - Enable toggle with no search: Should show "No multi-cast audiobooks found"
   - Enable toggle with search that matches no multi-cast books: Should show "No multi-cast audiobooks match your search"

**Expected Results**: The toggle provides visual feedback, filters correctly, persists during search operations, and displays appropriate messaging for all states.
