### PR TITLE
feat(GTM-2): Add Multi-Cast Narrator Support - Option 2 Implementation

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -2,17 +2,32 @@
 import { onMounted, ref, computed } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
+import type { Audiobook } from '@/types/spotify';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
+
+// Option 2: Separate Multi-Cast Filter Function
+const isMultiCastAudiobook = (audiobook: Audiobook): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
+  let audiobooks = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first if enabled
+  if (multiCastOnly.value) {
+    audiobooks = audiobooks.filter(isMultiCastAudiobook);
+  }
+  
+  // Then apply search filter if query exists
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return audiobooks;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return audiobooks.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -48,13 +63,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="controls-container">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-switch">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-input"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +95,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+              ? 'No multi-cast audiobooks found.' 
+              : multiCastOnly && searchQuery.trim()
+              ? 'No multi-cast audiobooks match your search.' 
+              : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,6 +177,13 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
@@ -164,6 +205,61 @@ onMounted(() => {
   outline: none;
   box-shadow: 0 4px 15px rgba(138, 66, 255, 0.2);
   background: #ffffff;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-input {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background: #ddd;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-input:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-input:checked + .toggle-slider::before {
+  transform: translateX(26px);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
+  white-space: nowrap;
 }
 
 .audiobook-grid {


### PR DESCRIPTION
# Add Multi-Cast Narrator Support - Option 2 Implementation

## Overview
This PR implements Option 2 from the technical review for GTM-2: Add multi-cast narrator support. The implementation provides a clean, reusable solution with a separate filter function that maintains good separation of concerns.

## Product Manager Summary
- Added a "Multi-Cast Only" toggle next to the search bar that filters audiobooks to show only those with multiple narrators
- Users can now easily discover multi-cast audiobooks which offer diverse voice acting performances
- The toggle works seamlessly with the existing search functionality
- Visual feedback shows active state and contextual messages when no results are found

## Technical Notes
**Architecture Decision**: Implemented Option 2 (Separate Multi-Cast Filter Function) as recommended in the technical review.

### Key Changes:
1. **Separate Filter Function**: Created `isMultiCastAudiobook(audiobook)` helper function for reusable, testable logic
2. **Composed Filtering**: Extended `filteredAudiobooks` computed property to chain multi-cast and search filters
3. **UI Component**: Added toggle switch with proper styling that matches design system
4. **Enhanced UX**: Contextual no-results messages and persistent toggle state during searches

### Implementation Details:
- Added `multiCastOnly` reactive state variable
- `isMultiCastAudiobook()` checks `audiobook.narrators.length > 1`
- Filter composition: multi-cast filter applied first, then search filter
- Handles both string and object narrator data types
- Clean separation allows for easy testing and future filter additions

## Feature Flow Diagram

```mermaid
flowchart TD
    A[User visits audiobooks page] --> B[All audiobooks displayed]
    B --> C{Multi-Cast toggle enabled?}
    C -->|No| D[Show all audiobooks]
    C -->|Yes| E[Filter to multi-cast only]
    D --> F{Search query entered?}
    E --> F
    F -->|No| G[Display current filtered results]
    F -->|Yes| H[Apply search filter to current results]
    H --> G
    G --> I{Any results?}
    I -->|Yes| J[Display audiobook cards]
    I -->|No| K[Show contextual no-results message]
```

## Testing Summary
**Added**: 0 new tests (visual testing only as requested)
**Removed**: 0 tests

## Human Testing Instructions
1. Visit http://localhost:5173
2. **Default State**: Verify all audiobooks are displayed with toggle off
3. **Multi-Cast Filter**: Click "Multi-Cast Only" toggle
   - Expected: Only audiobooks with multiple narrators shown (e.g., "Offside", "The Paradise Problem")
4. **Combined Search**: With toggle on, search for "paradise"
   - Expected: Only "The Paradise Problem" shown (multi-cast + matches search)
5. **Toggle State Persistence**: Perform search operations with toggle enabled
   - Expected: Toggle remains active throughout search operations
6. **Visual Feedback**: Observe toggle visual state changes
   - Expected: Toggle shows active state (purple gradient) when enabled

## Requirements Verification
✅ Multi-Cast Only toggle displayed next to search bar
✅ When enabled, shows only audiobooks with more than one narrator
✅ Toggle state persists during search operations  
✅ Toggle combines with text search functionality
✅ Toggle shows visual indication of active state
✅ User sees feedback when no multi-cast audiobooks match criteria

## Related Issues
- Implements Option 2 from GTM-2 technical review
- Addresses user story: "As a user, I want a toggle to filter audiobooks with multiple narrators"
