### PR TITLE
GTM-2: Add Multi-Cast Only filter (Option 1)

### DIFF
--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -1,40 +1,67 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useSpotifyStore } from '@/stores/spotify';
 import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const multiCastOnly = ref(false);
+
+// Load multiCastOnly state from localStorage on component mount
+onMounted(() => {
+  const savedMultiCastState = localStorage.getItem('multiCastOnly');
+  if (savedMultiCastState !== null) {
+    multiCastOnly.value = JSON.parse(savedMultiCastState);
+  }
+});
+
+// Watch multiCastOnly changes and save to localStorage
+watch(multiCastOnly, (newValue) => {
+  localStorage.setItem('multiCastOnly', JSON.stringify(newValue));
+});
+
+// Helper function to check if an audiobook has multiple narrators
+const isMultiCast = (audiobook: typeof spotifyStore.audiobooks[0]): boolean => {
+  return audiobook.narrators && audiobook.narrators.length > 1;
+};
 
 const filteredAudiobooks = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+  let results = spotifyStore.audiobooks;
+  
+  // Apply multi-cast filter first
+  if (multiCastOnly.value) {
+    results = results.filter(audiobook => isMultiCast(audiobook));
   }
   
-  const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
-    // Search by audiobook name
-    if (audiobook.name.toLowerCase().includes(query)) {
-      return true;
-    }
-    
-    // Search by author name
-    const authorMatch = audiobook.authors.some(author => 
-      author.name.toLowerCase().includes(query)
-    );
-    
-    // Search by narrator
-    const narratorMatch = audiobook.narrators?.some(narrator => {
-      if (typeof narrator === 'string') {
-        return narrator.toLowerCase().includes(query);
-      } else if (narrator && typeof narrator === 'object') {
-        return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+  // Apply search filter if there's a search query
+  if (searchQuery.value.trim()) {
+    const query = searchQuery.value.toLowerCase().trim();
+    results = results.filter(audiobook => {
+      // Search by audiobook name
+      if (audiobook.name.toLowerCase().includes(query)) {
+        return true;
       }
-      return false;
+      
+      // Search by author name
+      const authorMatch = audiobook.authors.some(author => 
+        author.name.toLowerCase().includes(query)
+      );
+      
+      // Search by narrator
+      const narratorMatch = audiobook.narrators?.some(narrator => {
+        if (typeof narrator === 'string') {
+          return narrator.toLowerCase().includes(query);
+        } else if (narrator && typeof narrator === 'object') {
+          return narrator.name ? narrator.name.toLowerCase().includes(query) : false;
+        }
+        return false;
+      });
+      
+      return authorMatch || narratorMatch;
     });
-    
-    return authorMatch || narratorMatch;
-  });
+  }
+  
+  return results;
 });
 
 onMounted(() => {
@@ -48,13 +75,26 @@ onMounted(() => {
     <section class="audiobooks">
       <div class="audiobooks-header">
         <h2>Latest Audiobooks via Spotify API</h2>
-        <div class="search-container">
-          <input 
-            type="text" 
-            v-model="searchQuery" 
-            placeholder="Search titles, authors or narrators..." 
-            class="search-input"
-          />
+        <div class="filter-controls">
+          <div class="search-container">
+            <input 
+              type="text" 
+              v-model="searchQuery" 
+              placeholder="Search titles, authors or narrators..." 
+              class="search-input"
+            />
+          </div>
+          <div class="toggle-container">
+            <label class="toggle-label">
+              <input 
+                type="checkbox" 
+                v-model="multiCastOnly"
+                class="toggle-checkbox"
+              />
+              <span class="toggle-slider"></span>
+              <span class="toggle-text">Multi-Cast Only</span>
+            </label>
+          </div>
         </div>
       </div>
       
@@ -67,7 +107,13 @@ onMounted(() => {
         <button @click="spotifyStore.fetchAudiobooks()">Try Again</button>
       </div>
       <div v-else>
-        <p v-if="filteredAudiobooks.length === 0" class="no-results">No audiobooks match your search.</p>
+        <p v-if="filteredAudiobooks.length === 0" class="no-results">
+          {{ multiCastOnly && !searchQuery.trim() 
+              ? 'No multi-cast audiobooks found.' 
+              : multiCastOnly && searchQuery.trim()
+              ? 'No multi-cast audiobooks match your search.'
+              : 'No audiobooks match your search.' }}
+        </p>
         <div v-else class="audiobook-grid">
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
@@ -143,9 +189,68 @@ onMounted(() => {
   border-radius: 2px;
 }
 
+.filter-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
 .search-container {
   position: relative;
   width: 300px;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 12px;
+}
+
+.toggle-checkbox {
+  display: none;
+}
+
+.toggle-slider {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  background-color: #ddd;
+  border-radius: 12px;
+  transition: background-color 0.3s ease;
+}
+
+.toggle-slider:before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.3s ease;
+}
+
+.toggle-checkbox:checked + .toggle-slider {
+  background: linear-gradient(90deg, #e942ff, #8a42ff);
+}
+
+.toggle-checkbox:checked + .toggle-slider:before {
+  transform: translateX(26px);
+}
+
+.toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #2a2d3e;
 }
 
 .search-input {
@@ -171,6 +276,22 @@ onMounted(() => {
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 30px;
   margin-bottom: 40px;
+}
+
+@media (max-width: 768px) {
+  .filter-controls {
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+  }
+  
+  .search-container {
+    width: 100%;
+  }
+  
+  .toggle-container {
+    justify-content: center;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
# GTM-2: Add Multi-Cast Only filter (Option 1)

Linked issue: https://linear.app/sourcegraph/issue/GTM-2/add-multi-cast-narrator-support

## Summary (PM-friendly)
Adds a "Multi-Cast Only" toggle next to the audiobook search bar. When enabled, the list shows only audiobooks with more than one narrator. The toggle works with text search and persists during the session via localStorage. Clear feedback is shown when no results match.

## Technical Notes (dev-friendly)
- Vue 3.5 + TS. Implemented Option 1 from the technical review.
- Introduced `multiCastOnly` reactive state with localStorage persistence (`multiCastOnly`).
- Extended `filteredAudiobooks` computed to:
  - Apply multi-cast filter first (narrators.length > 1)
  - Then apply existing text search (title, authors, narrators)
- UI: Accessible checkbox toggle with visual active state, placed beside the search input.
- Enhanced no-results messaging to reflect multi-cast context.

Changed files:
- client/src/views/AudiobooksView.vue

## How it works (diagram)
```mermaid
flowchart TD
  A[User toggles Multi-Cast Only] -->|v-model| B(multiCastOnly: boolean)
  B --> C{computed: filteredAudiobooks}
  C -->|if true| D[Filter: narrators.length > 1]
  D --> E[Apply text search filters]
  C -->|if false| E
  E --> F[Render AudiobookCard list]
  B --> G[Persist in localStorage]
```

## Human Testing Instructions
- Visit http://localhost:5173/
- Verify that a "Multi-Cast Only" toggle appears next to the search bar
- Toggle ON: only items with 2+ narrators should remain
- Type a search query (e.g. a narrator name); results should combine with the toggle
- Clear the search; toggle should still be active (state persists via localStorage)
- If no items match, verify the contextual no-results message

## Tests
- No unit tests added (per request). Visual QA performed locally.
