### PR TITLE
feat(KAN-3): Add hide audiobook functionality

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: []
+}>();
+
 const showModal = ref(false);
 
 // Use a separate function to open the modal
@@ -74,10 +78,17 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  emit('hide');
+};
 </script>
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" aria-label="Hide audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -148,6 +159,36 @@ const formatNarrators = (narrators: any[]) => {
 .audiobook-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s;
+  z-index: 10;
+  padding: 0;
+  line-height: 1;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(0, 0, 0, 0.9);
 }
 
 .audiobook-image {

--- a/client/src/components/__tests__/AudiobookCard.hide.spec.ts
+++ b/client/src/components/__tests__/AudiobookCard.hide.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobookCard from '../AudiobookCard.vue'
+
+describe('AudiobookCard - Hide Functionality', () => {
+  const audiobook = {
+    id: '1',
+    name: 'Test Audiobook',
+    authors: [{ name: 'Test Author' }],
+    narrators: [{ name: 'Test Narrator' }],
+    duration_ms: 3600000,
+    total_chapters: 10,
+    images: [{ url: 'test.jpg', height: 300, width: 300 }],
+    external_urls: { spotify: 'https://spotify.com' },
+    publisher: 'Test Publisher',
+    description: 'Test Description',
+    type: 'audiobook',
+    uri: 'spotify:audiobook:123',
+    release_date: '2024-01-01',
+    media_type: 'audio',
+  }
+
+  it('renders hide button', () => {
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook }
+    })
+
+    const hideBtn = wrapper.find('.hide-btn')
+    expect(hideBtn.exists()).toBe(true)
+  })
+
+  it('emits hide event when hide button is clicked', async () => {
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook }
+    })
+
+    const hideBtn = wrapper.find('.hide-btn')
+    await hideBtn.trigger('click')
+
+    expect(wrapper.emitted()).toHaveProperty('hide')
+    expect(wrapper.emitted('hide')).toHaveLength(1)
+  })
+
+  it('hide button has proper aria-label for accessibility', () => {
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook }
+    })
+
+    const hideBtn = wrapper.find('.hide-btn')
+    expect(hideBtn.attributes('aria-label')).toBe('Hide audiobook')
+  })
+})

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,17 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenBookIds = ref<Set<string>>(new Set());
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks.filter(audiobook => !hiddenBookIds.value.has(audiobook.id));
+  
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -36,6 +39,10 @@ const filteredAudiobooks = computed(() => {
     return authorMatch || narratorMatch;
   });
 });
+
+const handleHideBook = (id: string) => {
+  hiddenBookIds.value.add(id);
+};
 
 onMounted(() => {
   spotifyStore.fetchAudiobooks();
@@ -72,7 +79,8 @@ onMounted(() => {
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
-            :audiobook="audiobook" 
+            :audiobook="audiobook"
+            @hide="handleHideBook(audiobook.id)"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksView.hide.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView.hide.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobooksView from '../AudiobooksView.vue'
+
+const mockAudiobooks = [
+  {
+    id: '1',
+    name: 'Test Audiobook 1',
+    authors: [{ name: 'Author 1' }],
+    narrators: [{ name: 'Narrator 1' }],
+    duration_ms: 3600000,
+    total_chapters: 10,
+    images: [{ url: 'test1.jpg', height: 300, width: 300 }],
+    external_urls: { spotify: 'https://spotify.com/1' },
+    publisher: 'Publisher 1',
+    description: 'Description 1',
+    type: 'audiobook',
+    uri: 'spotify:audiobook:1',
+  },
+  {
+    id: '2',
+    name: 'Test Audiobook 2',
+    authors: [{ name: 'Author 2' }],
+    narrators: [{ name: 'Narrator 2' }],
+    duration_ms: 7200000,
+    total_chapters: 15,
+    images: [{ url: 'test2.jpg', height: 300, width: 300 }],
+    external_urls: { spotify: 'https://spotify.com/2' },
+    publisher: 'Publisher 2',
+    description: 'Description 2',
+    type: 'audiobook',
+    uri: 'spotify:audiobook:2',
+  }
+]
+
+vi.mock('@/stores/spotify', () => ({
+  useSpotifyStore: () => ({
+    audiobooks: mockAudiobooks,
+    isLoading: false,
+    error: null,
+    fetchAudiobooks: vi.fn()
+  })
+}))
+
+vi.mock('@/components/AudiobookCard.vue', () => ({
+  default: {
+    name: 'AudiobookCard',
+    props: ['audiobook'],
+    emits: ['hide'],
+    template: '<div class="audiobook-card-stub" @click="$emit(\'hide\')">{{ audiobook.name }}</div>'
+  }
+}))
+
+describe('AudiobooksView - Hide Functionality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initially displays all audiobooks', () => {
+    const wrapper = mount(AudiobooksView)
+    const cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(2)
+  })
+
+  it('hides audiobook when hide event is emitted', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    let cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(2)
+    
+    await cards[0].trigger('click')
+    
+    cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].text()).toBe('Test Audiobook 2')
+  })
+
+  it('can hide multiple audiobooks', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    let cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(2)
+    
+    await cards[0].trigger('click')
+    await cards[1].trigger('click')
+    
+    cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(0)
+  })
+
+  it('hidden audiobooks remain hidden when search query changes', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    const cards = wrapper.findAll('.audiobook-card-stub')
+    await cards[0].trigger('click')
+    
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('Test')
+    
+    const visibleCards = wrapper.findAll('.audiobook-card-stub')
+    expect(visibleCards).toHaveLength(1)
+    expect(visibleCards[0].text()).toBe('Test Audiobook 2')
+  })
+})


### PR DESCRIPTION
## KAN-3: Hide Audiobooks

### Summary for Product Manager
This PR implements a temporary hide feature for audiobooks. Users can now click an X button that appears when hovering over audiobook cards to remove them from view during their current browsing session. This helps users focus on content that matters to them without permanently deleting or affecting the data. Hidden books reappear when the page is refreshed.

### Technical Notes for Developers
- Added `hide` event emitter to `AudiobookCard.vue` component
- Created hide button with hover-activated visibility using CSS
- Implemented `hiddenBookIds` Set in `AudiobooksView.vue` to track hidden items
- Modified `filteredAudiobooks` computed property to exclude hidden items
- No persistence layer - state resets on page refresh (as per requirements)
- Added comprehensive unit tests for the hide functionality

### Architecture Diagram
```mermaid
graph TD
    A[User hovers over Audiobook Card] --> B[Hide button × appears]
    B --> C[User clicks × button]
    C --> D[handleHide emits 'hide' event]
    D --> E[AudiobooksView receives event]
    E --> F[Adds audiobook.id to hiddenBookIds Set]
    F --> G[filteredAudiobooks recomputes]
    G --> H[Card removed from display]
    I[Page Refresh] --> J[hiddenBookIds cleared]
    J --> K[All audiobooks visible again]
```

### Testing
**Added 7 new unit tests:**
1. `AudiobookCard.hide.spec.ts`:
   - Renders hide button ✓
   - Emits hide event when clicked ✓
   - Has proper aria-label for accessibility ✓

2. `AudiobooksView.hide.spec.ts`:
   - Initially displays all audiobooks ✓
   - Hides audiobook when hide event is emitted ✓
   - Can hide multiple audiobooks ✓
   - Hidden books remain hidden when search query changes ✓

**Test Results:** All 7 new tests passing

### Human Testing Instructions
1. Visit http://localhost:5173/ (ensure dev server is running)
2. Hover over any audiobook card
3. **Expected:** An X button should appear in the top-right corner of the card
4. Click the X button
5. **Expected:** The audiobook card should immediately disappear from the view
6. Hide 2-3 more audiobooks by repeating steps 2-5
7. Use the search bar to filter audiobooks
8. **Expected:** Previously hidden audiobooks remain hidden even during search
9. Refresh the page (F5 or Cmd+R)
10. **Expected:** All previously hidden audiobooks reappear in the list

### Related Issues
- JIRA: [KAN-3](https://your-jira-instance/browse/KAN-3)
- Amp Thread: https://ampcode.com/threads/T-ffdd26f0-f21f-4423-a732-04c7cebccfef
