### PR TITLE
KAN-3: Hide Audiobooks

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: [audiobookId: string]
+}>();
+
 const showModal = ref(false);
 
 // Use a separate function to open the modal
@@ -74,10 +78,17 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  emit('hide', props.audiobook.id);
+};
 </script>
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" aria-label="Hide audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -148,6 +159,37 @@ const formatNarrators = (narrators: any[]) => {
 .audiobook-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s, transform 0.2s;
+  padding: 0;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(233, 66, 255, 0.9);
+  transform: scale(1.1);
 }
 
 .audiobook-image {

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,20 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenAudiobookIds = ref<Set<string>>(new Set());
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks;
+  
+  // Filter out hidden audiobooks
+  books = books.filter(audiobook => !hiddenAudiobookIds.value.has(audiobook.id));
+  
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -36,6 +42,10 @@ const filteredAudiobooks = computed(() => {
     return authorMatch || narratorMatch;
   });
 });
+
+const hideAudiobook = (audiobookId: string) => {
+  hiddenAudiobookIds.value.add(audiobookId);
+};
 
 onMounted(() => {
   spotifyStore.fetchAudiobooks();
@@ -72,7 +82,8 @@ onMounted(() => {
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
-            :audiobook="audiobook" 
+            :audiobook="audiobook"
+            @hide="hideAudiobook"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksViewHide.spec.ts
+++ b/client/src/views/__tests__/AudiobooksViewHide.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobooksView from '../AudiobooksView.vue'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    getAudiobooks: vi.fn()
+  }
+}))
+
+vi.mock('@/components/AudiobookCard.vue', () => ({
+  default: {
+    name: 'AudiobookCard',
+    props: ['audiobook'],
+    emits: ['hide'],
+    template: '<div class="audiobook-card-stub" @click="$emit(\'hide\', audiobook.id)"></div>'
+  }
+}))
+
+describe('AudiobooksView - Hide Functionality', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should hide audiobook when hide event is emitted', async () => {
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        stubs: {
+          AudiobookCard: {
+            props: ['audiobook'],
+            emits: ['hide'],
+            template: '<div class="audiobook-card-stub" @click="$emit(\'hide\', audiobook.id)">{{ audiobook.name }}</div>'
+          }
+        }
+      }
+    })
+
+    // Set some test audiobooks in the store
+    const store = (wrapper.vm as any).spotifyStore
+    store.audiobooks = [
+      { id: '1', name: 'Book 1', authors: [], images: [] },
+      { id: '2', name: 'Book 2', authors: [], images: [] },
+      { id: '3', name: 'Book 3', authors: [], images: [] }
+    ]
+
+    await wrapper.vm.$nextTick()
+
+    // Initially, all 3 books should be visible
+    expect(wrapper.findAll('.audiobook-card-stub').length).toBe(3)
+
+    // Click the first card to emit hide event
+    await wrapper.findAll('.audiobook-card-stub')[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Now only 2 books should be visible
+    expect(wrapper.findAll('.audiobook-card-stub').length).toBe(2)
+    expect(wrapper.text()).toContain('Book 2')
+    expect(wrapper.text()).toContain('Book 3')
+    expect(wrapper.text()).not.toContain('Book 1')
+  })
+
+  it('should not persist hidden audiobooks on component remount', async () => {
+    const wrapper1 = mount(AudiobooksView, {
+      global: {
+        stubs: {
+          AudiobookCard: {
+            props: ['audiobook'],
+            emits: ['hide'],
+            template: '<div class="audiobook-card-stub" @click="$emit(\'hide\', audiobook.id)"></div>'
+          }
+        }
+      }
+    })
+
+    const store = (wrapper1.vm as any).spotifyStore
+    store.audiobooks = [
+      { id: '1', name: 'Book 1', authors: [], images: [] },
+      { id: '2', name: 'Book 2', authors: [], images: [] }
+    ]
+
+    await wrapper1.vm.$nextTick()
+
+    // Hide first book
+    await wrapper1.findAll('.audiobook-card-stub')[0].trigger('click')
+    await wrapper1.vm.$nextTick()
+    expect(wrapper1.findAll('.audiobook-card-stub').length).toBe(1)
+
+    // Unmount and remount component (simulating page refresh)
+    wrapper1.unmount()
+
+    const wrapper2 = mount(AudiobooksView, {
+      global: {
+        stubs: {
+          AudiobookCard: {
+            props: ['audiobook'],
+            emits: ['hide'],
+            template: '<div class="audiobook-card-stub"></div>'
+          }
+        }
+      }
+    })
+
+    const store2 = (wrapper2.vm as any).spotifyStore
+    store2.audiobooks = [
+      { id: '1', name: 'Book 1', authors: [], images: [] },
+      { id: '2', name: 'Book 2', authors: [], images: [] }
+    ]
+
+    await wrapper2.vm.$nextTick()
+
+    // All books should be visible again (no persistence)
+    expect(wrapper2.findAll('.audiobook-card-stub').length).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
Implements the ability for users to temporarily hide audiobooks from their view by clicking an X button that appears on hover.

## Changes Made
- Added a hide button (X) that appears when hovering over audiobook cards
- Implemented hide functionality that immediately removes books from view
- Hidden state is stored in-memory only (not persisted)
- Hidden books reappear on page refresh as per requirements

## Acceptance Criteria Met
✅ Given I am viewing the book list, when I hover over a book, then an X button appears
✅ Given the X button is visible, when I click it, then that book is immediately removed from view
✅ Given I have hidden one or more books, when I refresh the page, then all previously hidden books reappear in the list
✅ The hidden state is not persisted (no backend/localStorage storage required)

## Testing
- Added unit tests for hide functionality in `AudiobooksViewHide.spec.ts`
- Tests verify hiding behavior and non-persistence
- Project builds successfully
- All new tests pass

## Technical Notes
- Implemented using Vue 3.5 composition API with refs and computed properties
- Hide button styled with opacity transition for smooth hover effect
- Event emitter pattern used for parent-child communication
- No persistence layer required as per spec

## Related
- JIRA: KAN-3
- Amp Thread: https://ampcode.com/threads/T-f7d990fa-a5b6-4f8e-a6de-2742fa4f8c81