### PR TITLE
KAN-3: Add hide audiobook functionality

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: [id: string]
+}>();
+
 const showModal = ref(false);
 
 // Use a separate function to open the modal
@@ -74,10 +78,17 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  emit('hide', props.audiobook.id);
+};
 </script>
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" title="Hide this audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -148,6 +159,37 @@ const formatNarrators = (narrators: any[]) => {
 .audiobook-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  border-radius: 50%;
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.3s, background 0.2s, transform 0.2s;
+  padding: 0;
+  line-height: 1;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(233, 66, 255, 0.9);
+  transform: scale(1.1);
 }
 
 .audiobook-image {

--- a/client/src/components/__tests__/AudiobookCard-hide.spec.ts
+++ b/client/src/components/__tests__/AudiobookCard-hide.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobookCard from '../AudiobookCard.vue'
+
+describe('AudiobookCard hide functionality', () => {
+  const mockAudiobook = {
+    id: '123',
+    name: 'Test Audiobook',
+    authors: [{ name: 'Test Author' }],
+    narrators: ['Test Narrator'],
+    images: [{ url: 'test.jpg', height: 300, width: 300 }],
+    external_urls: { spotify: 'https://spotify.com' },
+    duration_ms: 3600000,
+    total_chapters: 10,
+    type: 'audiobook' as const,
+    uri: 'spotify:audiobook:123',
+    publisher: 'Test Publisher',
+    description: 'Test description',
+    html_description: '<p>Test description</p>',
+    edition: 'Standard',
+    explicit: false,
+    languages: ['en'],
+    media_type: 'audio'
+  }
+
+  it('should emit hide event when hide button is clicked', async () => {
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook: mockAudiobook }
+    })
+
+    const hideBtn = wrapper.find('.hide-btn')
+    expect(hideBtn.exists()).toBe(true)
+
+    await hideBtn.trigger('click')
+
+    expect(wrapper.emitted('hide')).toBeTruthy()
+    expect(wrapper.emitted('hide')?.[0]).toEqual(['123'])
+  })
+
+  it('should render hide button with correct attributes', () => {
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook: mockAudiobook }
+    })
+
+    const hideBtn = wrapper.find('.hide-btn')
+    expect(hideBtn.text()).toBe('×')
+    expect(hideBtn.attributes('title')).toBe('Hide this audiobook')
+  })
+})

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,23 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenAudiobookIds = ref<Set<string>>(new Set());
+
+const hideAudiobook = (id: string) => {
+  hiddenAudiobookIds.value.add(id);
+};
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks;
+  
+  books = books.filter(audiobook => !hiddenAudiobookIds.value.has(audiobook.id));
+  
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -73,6 +82,7 @@ onMounted(() => {
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
             :audiobook="audiobook" 
+            @hide="hideAudiobook"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksView-hide.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView-hide.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobooksView from '../AudiobooksView.vue'
+
+const mockSpotifyStore = {
+  audiobooks: [
+    {
+      id: '1',
+      name: 'Audiobook 1',
+      authors: [{ name: 'Author 1' }],
+      narrators: ['Narrator 1'],
+      images: [{ url: 'test1.jpg', height: 300, width: 300 }],
+      external_urls: { spotify: 'https://spotify.com/1' },
+      duration_ms: 3600000,
+      total_chapters: 10,
+      type: 'audiobook' as const,
+      uri: 'spotify:audiobook:1',
+      publisher: 'Publisher 1',
+      description: 'Description 1',
+      html_description: '<p>Description 1</p>',
+      edition: 'Standard',
+      explicit: false,
+      languages: ['en'],
+      media_type: 'audio'
+    },
+    {
+      id: '2',
+      name: 'Audiobook 2',
+      authors: [{ name: 'Author 2' }],
+      narrators: ['Narrator 2'],
+      images: [{ url: 'test2.jpg', height: 300, width: 300 }],
+      external_urls: { spotify: 'https://spotify.com/2' },
+      duration_ms: 7200000,
+      total_chapters: 15,
+      type: 'audiobook' as const,
+      uri: 'spotify:audiobook:2',
+      publisher: 'Publisher 2',
+      description: 'Description 2',
+      html_description: '<p>Description 2</p>',
+      edition: 'Standard',
+      explicit: false,
+      languages: ['en'],
+      media_type: 'audio'
+    }
+  ],
+  isLoading: false,
+  error: null,
+  fetchAudiobooks: vi.fn()
+}
+
+vi.mock('@/stores/spotify', () => ({
+  useSpotifyStore: () => mockSpotifyStore
+}))
+
+vi.mock('@/components/AudiobookCard.vue', () => ({
+  default: {
+    name: 'AudiobookCard',
+    props: ['audiobook'],
+    emits: ['hide'],
+    template: '<div class="audiobook-card-stub" @click="$emit(\'hide\', audiobook.id)"></div>'
+  }
+}))
+
+describe('AudiobooksView hide functionality', () => {
+  it('should hide audiobook when hide event is emitted', async () => {
+    const wrapper = mount(AudiobooksView)
+
+    const cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards).toHaveLength(2)
+
+    await cards[0].trigger('click')
+
+    await wrapper.vm.$nextTick()
+
+    const updatedCards = wrapper.findAll('.audiobook-card-stub')
+    expect(updatedCards).toHaveLength(1)
+  })
+
+  it('should not persist hidden state on page refresh', () => {
+    const wrapper = mount(AudiobooksView)
+
+    expect(wrapper.findAll('.audiobook-card-stub')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

Implements KAN-3: Hide Audiobooks feature. Users can now temporarily hide audiobooks they're not interested in by clicking an X button that appears when hovering over audiobook cards.

## JIRA Issue

[KAN-3](https://isurufonseka.atlassian.net/browse/KAN-3)

## Product Manager Summary

This feature enhances the user browsing experience by allowing users to temporarily remove audiobooks from their view during a browsing session. When a user hovers over an audiobook card, an X button appears in the top-right corner. Clicking this button immediately removes the book from view, helping users focus on the content that matters to them. The hidden state is session-only and does not persist across page refreshes, ensuring a clean slate on each visit.

## Technical Notes

### Changes Made

1. **AudiobookCard.vue**
   - Added `hide` event emitter
   - Implemented `handleHide` function to emit hide event with audiobook ID
   - Added hide button (X) with hover-only visibility
   - Styled hide button with smooth transitions and purple accent on hover

2. **AudiobooksView.vue**
   - Added `hiddenAudiobookIds` Set to track hidden audiobooks
   - Implemented `hideAudiobook` function to add IDs to hidden set
   - Updated `filteredAudiobooks` computed property to filter out hidden books
   - Connected hide event from AudiobookCard to hideAudiobook handler

3. **Unit Tests**
   - Created `AudiobookCard-hide.spec.ts` to test hide button emission
   - Created `AudiobooksView-hide.spec.ts` to test filtering logic
   - Both tests passing successfully

### Implementation Details

- Hidden state uses a reactive Set for O(1) lookup performance
- X button positioned absolutely in top-right corner with z-index 10
- Opacity transition (0 to 1) on card hover for smooth UX
- Event propagation stopped to prevent modal opening when hiding
- No localStorage or backend persistence (session-only as per requirements)

## Architecture Diagram

```mermaid
sequenceDiagram
    participant User
    participant AudiobookCard
    participant AudiobooksView
    participant Store
    
    User->>AudiobookCard: Hovers over card
    AudiobookCard->>AudiobookCard: Show X button (opacity: 0 → 1)
    User->>AudiobookCard: Clicks X button
    AudiobookCard->>AudiobookCard: handleHide(event)
    AudiobookCard->>AudiobooksView: emit('hide', audiobook.id)
    AudiobooksView->>AudiobooksView: hideAudiobook(id)
    AudiobooksView->>AudiobooksView: hiddenAudiobookIds.add(id)
    AudiobooksView->>AudiobooksView: filteredAudiobooks recomputes
    Store->>AudiobooksView: audiobooks list
    AudiobooksView->>AudiobooksView: Filter out hidden IDs
    AudiobooksView->>User: Re-render without hidden book
    User->>User: Refreshes page
    AudiobooksView->>AudiobooksView: hiddenAudiobookIds = new Set()
    AudiobooksView->>User: All books visible again
```

## Testing

### Unit Tests Added
- ✅ `AudiobookCard-hide.spec.ts`: 2 tests
  - "should emit hide event when hide button is clicked"
  - "should render hide button with correct attributes"
- ✅ `AudiobooksView-hide.spec.ts`: 2 tests
  - "should hide audiobook when hide event is emitted"
  - "should not persist hidden state on page refresh"

**Test Results**: Added 4 tests, removed 0 tests. All new tests passing.

### Manual Testing Instructions

1. Visit http://localhost:5173 (with dev server running)
2. Hover over any audiobook card
3. **Expected**: X button appears in top-right corner with smooth fade-in
4. Click the X button
5. **Expected**: The audiobook immediately disappears from the grid
6. Hide multiple audiobooks
7. **Expected**: Each clicked book is removed from view
8. Refresh the page (F5 or Cmd+R)
9. **Expected**: All previously hidden books reappear in the list

## Acceptance Criteria

✅ Given I am viewing the book list, when I hover over a book, then an X button appears  
✅ Given the X button is visible, when I click it, then that book is immediately removed from view  
✅ Given I have hidden one or more books, when I refresh the page, then all previously hidden books reappear in the list  
✅ The hidden state is not persisted (no backend/localStorage storage required)

## Screenshots

_No screenshots required per AGENT.md guidelines_
