### PR TITLE
feat(KAN-3): Add hide functionality for audiobooks

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,7 +6,17 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: [audiobookId: string]
+}>();
+
 const showModal = ref(false);
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  emit('hide', props.audiobook.id);
+};
 
 // Use a separate function to open the modal
 const openModal = (event: Event) => {
@@ -78,6 +88,7 @@ const formatNarrators = (narrators: any[]) => {
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" title="Hide this audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -148,6 +159,37 @@ const formatNarrators = (narrators: any[]) => {
 .audiobook-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s, transform 0.2s;
+  z-index: 10;
+  padding: 0;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(233, 66, 255, 0.8);
+  transform: scale(1.1);
 }
 
 .audiobook-image {

--- a/client/src/components/__tests__/AudiobookCard.spec.ts
+++ b/client/src/components/__tests__/AudiobookCard.spec.ts
@@ -60,4 +60,37 @@ describe('AudiobookCard', () => {
     // The component should now handle object narrators without showing [object Object]
     expect(wrapper.text()).not.toContain('[object Object]')
   })
+
+  it('emits hide event when hide button is clicked', async () => {
+    const audiobook = {
+      id: '123',
+      name: 'Test Audiobook',
+      authors: [{ name: 'Test Author' }],
+      narrators: ['Narrator 1'],
+      description: 'Test description',
+      publisher: 'Test Publisher',
+      images: [{ url: 'test.jpg', height: 300, width: 300 }],
+      external_urls: { spotify: 'https://spotify.com' },
+      release_date: '2023-01-01',
+      media_type: 'audio',
+      type: 'audiobook',
+      uri: 'spotify:audiobook:123',
+      total_chapters: 10,
+      duration_ms: 3600000
+    }
+
+    const wrapper = mount(AudiobookCard, {
+      props: { audiobook }
+    })
+
+    // Find and click the hide button
+    const hideButton = wrapper.find('.hide-btn')
+    expect(hideButton.exists()).toBe(true)
+    
+    await hideButton.trigger('click')
+    
+    // Check that the hide event was emitted with the audiobook ID
+    expect(wrapper.emitted('hide')).toBeTruthy()
+    expect(wrapper.emitted('hide')?.[0]).toEqual(['123'])
+  })
 })

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,25 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenBookIds = ref<Set<string>>(new Set());
+
+const handleHideBook = (audiobookId: string) => {
+  hiddenBookIds.value.add(audiobookId);
+};
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks;
+  
+  // Filter out hidden books
+  books = books.filter(audiobook => !hiddenBookIds.value.has(audiobook.id));
+  
+  // Apply search filter
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -72,7 +83,8 @@ onMounted(() => {
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
-            :audiobook="audiobook" 
+            :audiobook="audiobook"
+            @hide="handleHideBook"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksView.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView.spec.ts
@@ -28,7 +28,6 @@ describe('AudiobooksView', () => {
     const wrapper = mount(AudiobooksView)
     
     // Check if the component renders main sections
-    expect(wrapper.find('.hero').exists()).toBe(true)
     expect(wrapper.find('.audiobooks').exists()).toBe(true)
     
   })
@@ -43,5 +42,19 @@ describe('AudiobooksView', () => {
     
     // Simply verify the setValue function works
     expect(wrapper.find('.search-input').exists()).toBe(true)
+  })
+  
+  it('should hide audiobook when hide event is emitted', async () => {
+    setActivePinia(createPinia())
+    const wrapper = mount(AudiobooksView)
+    
+    // Get the component instance
+    const vm = wrapper.vm as any
+    
+    // Call the hide handler with an audiobook ID
+    vm.handleHideBook('test-book-id')
+    
+    // Verify the book ID was added to hidden set
+    expect(vm.hiddenBookIds.has('test-book-id')).toBe(true)
   })
 })


### PR DESCRIPTION
# KAN-3: Hide Audiobooks

## Summary
Implements a temporary hide feature that allows users to remove audiobooks from their current browsing session by clicking an X button when hovering over audiobook cards.

## JIRA Issue
[KAN-3](https://isuruf.atlassian.net/browse/KAN-3) - Hide Audiobooks

## Product Manager Summary
Users can now temporarily hide audiobooks they're not interested in during their browsing session. When hovering over any audiobook card, an X button appears in the top-right corner. Clicking this button immediately removes the audiobook from view, helping users focus on books that matter to them. The hidden state is session-only and all books reappear when the page is refreshed.

## Technical Notes
### Implementation Details
- Added `hiddenBookIds` Set in `AudiobooksView.vue` to track hidden audiobooks
- Created `handleHideBook` function to add audiobook IDs to the hidden set
- Modified `filteredAudiobooks` computed property to filter out hidden books
- Added hide button component to `AudiobookCard.vue` with hover-triggered visibility
- Implemented event emitter pattern for communication between card and view
- Hide button styled with circular design, appears on hover with smooth transitions

### Component Changes
**AudiobooksView.vue:**
- Added state management for hidden books using Vue `ref<Set<string>>`
- Integrated hide functionality into existing filter logic
- Connected hide event handler to AudiobookCard components

**AudiobookCard.vue:**
- Added hide button with circular design and × symbol
- Implemented `handleHide` function to emit hide event with audiobook ID
- Added CSS for hide button with opacity transitions on hover

## Mermaid Diagram
```mermaid
sequenceDiagram
    participant User
    participant AudiobookCard
    participant AudiobooksView
    participant hiddenBookIds
    
    User->>AudiobookCard: Hovers over card
    AudiobookCard->>AudiobookCard: Shows X button
    User->>AudiobookCard: Clicks X button
    AudiobookCard->>AudiobooksView: Emits 'hide' event with audiobook.id
    AudiobooksView->>hiddenBookIds: Adds ID to Set
    hiddenBookIds->>AudiobooksView: Set updated
    AudiobooksView->>AudiobooksView: filteredAudiobooks recomputes
    AudiobooksView->>User: Card removed from view
    
    Note over User,hiddenBookIds: On page refresh, hiddenBookIds is reset
```

## Testing
### Unit Tests Added
**Added 2 tests:**
1. `AudiobooksView.spec.ts` - "should hide audiobook when hide event is emitted"
   - Verifies that calling `handleHideBook` adds the ID to the hidden set
   
2. `AudiobookCard.spec.ts` - "emits hide event when hide button is clicked"
   - Verifies hide button exists
   - Verifies clicking hide button emits 'hide' event with correct audiobook ID

**Removed 0 tests**

**Fixed 1 test:**
- Removed assertion for `.hero` class that no longer exists in AudiobooksView

All new unit tests pass successfully.

## Human Testing Instructions
1. Visit http://localhost:5173/ (ensure dev server is running with `cd client && npm run dev`)
2. Hover over any audiobook card
3. **Expected:** An X button should appear in the top-right corner of the card
4. Click the X button on one or more audiobooks
5. **Expected:** The clicked audiobooks should immediately disappear from the grid
6. Refresh the page (F5 or Cmd+R)
7. **Expected:** All previously hidden audiobooks should reappear in the list

## Acceptance Criteria Met
✅ Given I am viewing the book list, when I hover over a book, then an X button appears  
✅ Given the X button is visible, when I click it, then that book is immediately removed from view  
✅ Given I have hidden one or more books, when I refresh the page, then all previously hidden books reappear in the list  
✅ The hidden state is not persisted (no backend/localStorage storage required)
