### PR TITLE
KAN-4: Implement Sentry logging for client-side error tracking

### DIFF
--- a/SENTRY_IMPLEMENTATION_PLAN.md
+++ b/SENTRY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Sentry Logging for Client-Side
+
+## Overview
+Implement Sentry error and performance monitoring on the client-side of the demo-latest-audiobooks project.
+
+## Technology Stack
+- Sentry SDK: `@sentry/vue` (latest version)
+- Vite Plugin: `@sentry/vite-plugin` for source map uploading
+- Framework: Vue 3.5 with TypeScript
+- State Management: Pinia
+- Build Tool: Vite
+
+## Implementation Steps
+
+### 1. Install Dependencies
+```bash
+cd client
+npm install @sentry/vue --save
+npm install @sentry/vite-plugin --save-dev
+```
+
+### 2. Create Sentry Configuration File
+- Create `client/src/sentry.ts` with Sentry initialization logic
+- Configure integrations:
+  - Browser Tracing (performance monitoring)
+  - Replay (session replay for debugging)
+  - Pinia Plugin (state management tracking)
+- Use environment variable for DSN: `VITE_SENTRY_DSN`
+
+### 3. Update Main Application Entry Point
+- Import Sentry configuration in `main.ts` before app initialization
+- Initialize Sentry with app and router instances
+- Add Pinia plugin for state tracking
+
+### 4. Configure Vite for Source Maps
+- Update `vite.config.ts` to:
+  - Enable source map generation in build
+  - Add Sentry Vite plugin for automatic source map upload
+- Use environment variables:
+  - `SENTRY_AUTH_TOKEN` (for source map upload)
+  - `SENTRY_ORG` (Sentry organization slug)
+  - `SENTRY_PROJECT` (Sentry project name)
+
+### 5. Environment Configuration
+- Create `.env.example` with template for required variables:
+  ```
+  VITE_SENTRY_DSN=
+  SENTRY_AUTH_TOKEN=
+  SENTRY_ORG=
+  SENTRY_PROJECT=
+  ```
+- Update `.gitignore` to exclude `.env` if not already present
+
+### 6. Configuration Options
+- **Sample Rates:**
+  - `tracesSampleRate: 0.1` (10% of transactions for performance)
+  - `replaysSessionSampleRate: 0.1` (10% of sessions)
+  - `replaysOnErrorSampleRate: 1.0` (100% of error sessions)
+- **Trace Propagation:**
+  - Include localhost for development
+  - Include production API endpoints
+
+### 7. Testing
+- Verify Sentry is initialized correctly
+- Test error capture by throwing test error
+- Verify source maps are uploaded in production build
+- Check Pinia state is captured in error context
+
+## Files to Create/Modify
+
+### New Files:
+1. `client/src/sentry.ts` - Sentry initialization
+2. `client/.env.example` - Environment variable template
+
+### Modified Files:
+1. `client/src/main.ts` - Add Sentry import and initialization
+2. `client/vite.config.ts` - Add Sentry plugin and source map config
+3. `client/package.json` - Add dependencies (via npm install)
+
+## Security Considerations
+- DSN is public and safe to expose in client-side code
+- Auth token must be kept secret (environment variable only)
+- Never commit `.env` file to repository
+- Use different Sentry projects for dev/staging/production
+
+## Production Checklist
+- [ ] Adjust sample rates for production traffic volume
+- [ ] Configure release tracking for deployment versioning
+- [ ] Set up alerts in Sentry dashboard
+- [ ] Configure user feedback integration (optional)
+- [ ] Test source map upload in CI/CD pipeline

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,9 @@
+# Sentry Configuration
+# Get your DSN from: https://sentry.io/settings/[organization]/projects/[project]/keys/
+VITE_SENTRY_DSN=
+
+# Sentry Source Map Upload (for production builds only)
+# Get auth token from: https://sentry.io/settings/account/api/auth-tokens/
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -28,3 +28,4 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+.env

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@sentry/vue": "^10.22.0",
         "axios": "^1.9.0",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
@@ -16,6 +17,7 @@
       "devDependencies": {
         "@pinia/testing": "^1.0.1",
         "@playwright/test": "^1.52.0",
+        "@sentry/vite-plugin": "^4.5.0",
         "@tsconfig/node22": "^22.0.1",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.14.0",
@@ -1849,6 +1851,406 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.22.0.tgz",
+      "integrity": "sha512-BpJoLZEyJr7ORzkCrIjxRTnFWwO1mJNICVh3B9g5d9245niGT4OJvRozmLz89WgJkZFHWu84ls6Xfq5b/3tGFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.22.0.tgz",
+      "integrity": "sha512-zXySOin/gGHPV+yKaHqjN9YZ7psEJwzLn8PzCLeo+4REzF1eQwbYZIgOxJFD32z8s3nZiABSWFM/n1CvVfMEsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.22.0.tgz",
+      "integrity": "sha512-JNE4kHAQSG4/V+J+Zog3vKBWgOe9H33ol/MEU1RuLM/4I+uLf4mTetwnS9ilpnnW/Z/gQYfA+R3CiMrZtqTivw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.22.0",
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.22.0.tgz",
+      "integrity": "sha512-DE4JNUskJg+O+wFq42W5gAa/99aD5k7TfGOwABxvnzFv8vkKA7pqXwPbFFPzypdKIkln+df7RmbnDwQRNg6/lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.22.0",
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.5.0.tgz",
+      "integrity": "sha512-9sn9tJFtNnhSitPXW8hTuteefGMBbnPFyDER8dz+2sgdvcdq7T99lEwprMf8gUv5JCiDKIvtLe20Sf/4KPAahA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.22.0.tgz",
+      "integrity": "sha512-wD2XqN+yeBpQFfdPo6+wlKDMyyuDctVGzZWE4qTPntICKQuwMdAfeq5Ma89ad0Dw+bzG9UijGeyuJQlswF87Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.22.0",
+        "@sentry-internal/feedback": "10.22.0",
+        "@sentry-internal/replay": "10.22.0",
+        "@sentry-internal/replay-canvas": "10.22.0",
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-4.5.0.tgz",
+      "integrity": "sha512-LTgYe7qGgAP0BpsyCTpjk756l6wZUv3MtCE+G0qzlpsQ2AljYe2bN4qjDy0bQrsPo0QzNQm+S6d0zogcJj/tqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "4.5.0",
+        "@sentry/cli": "^2.51.0",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^9.3.2",
+        "magic-string": "0.30.8",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.57.0.tgz",
+      "integrity": "sha512-oC4HPrVIX06GvUTgK0i+WbNgIA9Zl5YEcwf9N4eWFJJmjonr2j4SML9Hn2yNENbUWDgwepy4MLod3P8rM4bk/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.57.0",
+        "@sentry/cli-linux-arm": "2.57.0",
+        "@sentry/cli-linux-arm64": "2.57.0",
+        "@sentry/cli-linux-i686": "2.57.0",
+        "@sentry/cli-linux-x64": "2.57.0",
+        "@sentry/cli-win32-arm64": "2.57.0",
+        "@sentry/cli-win32-i686": "2.57.0",
+        "@sentry/cli-win32-x64": "2.57.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.57.0.tgz",
+      "integrity": "sha512-v1wYQU3BcCO+Z3OVxxO+EnaW4oQhuOza6CXeYZ0z5ftza9r0QQBLz3bcZKTVta86xraNm0z8GDlREwinyddOxQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.57.0.tgz",
+      "integrity": "sha512-uNHB8xyygqfMd1/6tFzl9NUkuVefg7jdZtM/vVCQVaF/rJLWZ++Wms+LLhYyKXKN8yd7J9wy7kTEl4Qu4jWbGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.57.0.tgz",
+      "integrity": "sha512-Kh1jTsMV5Fy/RvB381N/woXe1qclRMqsG6kM3Gq6m6afEF/+k3PyQdNW3HXAola6d63EptokLtxPG2xjWQ+w9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.57.0.tgz",
+      "integrity": "sha512-EYXghoK/tKd0zqz+KD/ewXXE3u1HLCwG89krweveytBy/qw7M5z58eFvw+iGb1Vnbl1f/fRD0G4E0AbEsPfmpg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.57.0.tgz",
+      "integrity": "sha512-CyZrP/ssHmAPLSzfd4ydy7icDnwmDD6o3QjhkWwVFmCd+9slSBMQxpIqpamZmrWE6X4R+xBRbSUjmdoJoZ5yMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.57.0.tgz",
+      "integrity": "sha512-wji/GGE4Lh5I/dNCsuVbg6fRvttvZRG6db1yPW1BSvQRh8DdnVy1CVp+HMqSq0SRy/S4z60j2u+m4yXMoCL+5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.57.0.tgz",
+      "integrity": "sha512-hWvzyD7bTPh3b55qvJ1Okg3Wbl0Km8xcL6KvS7gfBl6uss+I6RldmQTP0gJKdHSdf/QlJN1FK0b7bLnCB3wHsg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.57.0.tgz",
+      "integrity": "sha512-QWYV/Y0sbpDSTyA4XQBOTaid4a6H2Iwa1Z8UI+qNxFlk0ADSEgIqo2NrRHDU8iRnghTkecQNX1NTt/7mXN3f/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.22.0.tgz",
+      "integrity": "sha512-V1oeHbrOKzxadsCmgtPku3v3Emo/Bpb3VSuKmlLrQefiHX98MWtjJ3XDGfduzD5/dCdh0r/OOLwjcmrO/PZ2aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-4.5.0.tgz",
+      "integrity": "sha512-8AcTuAmu2NFCkSgVroCeu/ExZeMDVGdgrXq9MzgE5LT2bcomKsHiAifhitq64QwFEfL6CFt3TYEsw0rm0AoRhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "4.5.0",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/vue": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.22.0.tgz",
+      "integrity": "sha512-rzwGkFKqAFsH1GGsH83lo0GdZ29yXHOReJqFOzexbhX2j0mtKmFqSwAqKTDbPz/snIQIO5eKtXHTF6kpZ+CkiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.22.0",
+        "@sentry/core": "10.22.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "pinia": "2.x || 3.x",
+        "vue": "2.x || 3.x"
+      },
+      "peerDependenciesMeta": {
+        "pinia": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -2737,6 +3139,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2777,6 +3193,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/birpc": {
       "version": "2.3.0",
@@ -2962,6 +3391,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -3207,6 +3674,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -3946,6 +4426,13 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4276,6 +4763,19 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -4865,6 +5365,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4886,6 +5432,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-normalize-package-bin": {
@@ -5413,6 +5969,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5469,6 +6035,19 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -6155,6 +6734,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -6631,6 +7223,23 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@sentry/vue": "^10.22.0",
     "axios": "^1.9.0",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@pinia/testing": "^1.0.1",
     "@playwright/test": "^1.52.0",
+    "@sentry/vite-plugin": "^4.5.0",
     "@tsconfig/node22": "^22.0.1",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.14.0",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,13 +2,20 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { createSentryPiniaPlugin } from '@sentry/vue'
 
 import App from './App.vue'
 import router from './router'
+import { initSentry } from './sentry'
 
 const app = createApp(App)
+const pinia = createPinia()
 
-app.use(createPinia())
+initSentry(app, router)
+
+pinia.use(createSentryPiniaPlugin())
+
+app.use(pinia)
 app.use(router)
 
 app.mount('#app')

--- a/client/src/sentry.ts
+++ b/client/src/sentry.ts
@@ -1,0 +1,26 @@
+import * as Sentry from '@sentry/vue'
+import type { Router } from 'vue-router'
+import type { App } from 'vue'
+
+export function initSentry(app: App, router: Router) {
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+
+  if (!dsn) {
+    console.warn('Sentry DSN not configured. Error tracking is disabled.')
+    return
+  }
+
+  Sentry.init({
+    app,
+    dsn,
+    integrations: [
+      Sentry.browserTracingIntegration({ router }),
+      Sentry.replayIntegration()
+    ],
+    tracesSampleRate: 0.1,
+    tracePropagationTargets: ['localhost', /^https:\/\/.*\.audiobooks\.io\/api/],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    environment: import.meta.env.MODE || 'development'
+  })
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import vueDevTools from 'vite-plugin-vue-devtools'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,10 +12,19 @@ export default defineConfig({
     vue(),
     vueJsx(),
     vueDevTools(),
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      disable: !process.env.SENTRY_AUTH_TOKEN,
+    }),
   ],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
+  },
+  build: {
+    sourcemap: true,
   },
 })


### PR DESCRIPTION
## Related Issue
[KAN-4](https://isuru-f.atlassian.net/browse/KAN-4) - SPIKE: Sentry Logging

## Summary
This PR implements comprehensive Sentry error tracking and performance monitoring for the client-side Vue 3 application. The implementation enables automatic error capture, performance monitoring, session replay, and Pinia state tracking in error reports.

## Product Manager Summary
The application now has robust error monitoring and performance tracking capabilities through Sentry integration. This will allow the team to:
- Automatically capture and track client-side errors in production
- Monitor application performance with detailed metrics
- Replay user sessions when errors occur to understand context
- Track application state (Pinia store) when errors happen
- Upload source maps for readable stack traces in production

## Technical Notes
### Implementation Details
- **Sentry SDK**: Added `@sentry/vue` for Vue 3-specific error and performance monitoring
- **Build Tool Integration**: Integrated `@sentry/vite-plugin` for automatic source map upload during production builds
- **Configuration**: Created modular Sentry configuration in `client/src/sentry.ts`
- **State Tracking**: Integrated Sentry Pinia plugin to capture store state in error contexts
- **Environment Variables**: Used environment variables for DSN and upload credentials

### Integrations Configured
1. **Browser Tracing**: Performance monitoring with 10% sample rate
2. **Session Replay**: 10% of normal sessions, 100% of error sessions
3. **Pinia Plugin**: State management tracking in error reports

### Configuration Files Modified/Created
- `client/src/sentry.ts` - New: Sentry initialization module
- `client/src/main.ts` - Modified: Added Sentry initialization and Pinia plugin
- `client/vite.config.ts` - Modified: Added source map generation and Sentry Vite plugin
- `client/.env.example` - New: Environment variable template
- `client/.gitignore` - Modified: Added .env exclusion
- `SENTRY_IMPLEMENTATION_PLAN.md` - New: Comprehensive implementation documentation

## Architecture Diagram
\`\`\`mermaid
graph TB
    A[Vue App Initialization] --> B[Sentry Init]
    B --> C[Browser Tracing Integration]
    B --> D[Replay Integration]
    B --> E[Pinia Plugin]
    
    F[User Action] --> G[Error Occurs]
    G --> H[Sentry Captures Error]
    H --> I[Includes Pinia State]
    H --> J[Includes Replay Session]
    H --> K[Includes Performance Trace]
    
    L[Production Build] --> M[Vite Build Process]
    M --> N[Generate Source Maps]
    N --> O[Sentry Plugin]
    O --> P[Upload to Sentry]
    
    subgraph "Error Context"
        I
        J
        K
    end
    
    subgraph "Build Pipeline"
        M
        N
        O
        P
    end
\`\`\`

## Testing
### Unit Tests
Added 0 tests, removed 0 tests
- No unit tests were added as Sentry initialization is framework integration code
- Existing tests continue to pass (pre-existing test failures are unrelated)

### Manual Testing Instructions
1. Clone the repository and checkout this branch
2. Navigate to `client/` directory
3. Copy `.env.example` to `.env` and add your Sentry DSN:
   \`\`\`bash
   cp .env.example .env
   # Edit .env and add VITE_SENTRY_DSN=your-sentry-dsn
   \`\`\`
4. Install dependencies: \`npm install\`
5. Start dev server: \`npm run dev\`
6. Visit http://localhost:5173
7. Open browser console and verify Sentry initialization message
8. Trigger a test error in the application and verify it appears in your Sentry dashboard
9. For production build testing:
   - Set SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT in .env
   - Run \`npm run build\`
   - Verify source maps are uploaded to Sentry

## CI/CD Considerations
- Source map upload requires SENTRY_AUTH_TOKEN to be set in CI environment
- The Sentry Vite plugin is disabled when SENTRY_AUTH_TOKEN is not present
- Recommended to use different Sentry projects for staging and production environments

## Amp Thread
https://ampcode.com/threads/T-bfdc85fd-cdc0-4346-8aba-fa913f2036d8
