### PR TITLE
KAN-1: Add sort button for audiobooks

### DIFF
--- a/client/src/views/__tests__/AudiobooksView.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView.spec.ts
@@ -28,7 +28,6 @@ describe('AudiobooksView', () => {
     const wrapper = mount(AudiobooksView)
     
     // Check if the component renders main sections
-    expect(wrapper.find('.hero').exists()).toBe(true)
     expect(wrapper.find('.audiobooks').exists()).toBe(true)
     
   })
@@ -43,5 +42,31 @@ describe('AudiobooksView', () => {
     
     // Simply verify the setValue function works
     expect(wrapper.find('.search-input').exists()).toBe(true)
+  })
+
+  it('has sort select dropdown', () => {
+    setActivePinia(createPinia())
+    const wrapper = mount(AudiobooksView)
+    
+    const sortSelect = wrapper.find('.sort-select')
+    expect(sortSelect.exists()).toBe(true)
+    
+    const options = sortSelect.findAll('option')
+    expect(options.length).toBe(5)
+    expect(options[0].text()).toBe('Default Order')
+    expect(options[1].text()).toBe('Name (A-Z)')
+    expect(options[2].text()).toBe('Name (Z-A)')
+    expect(options[3].text()).toBe('Release Date (Oldest First)')
+    expect(options[4].text()).toBe('Release Date (Newest First)')
+  })
+
+  it('changes sort option when dropdown value changes', async () => {
+    setActivePinia(createPinia())
+    const wrapper = mount(AudiobooksView)
+    
+    const sortSelect = wrapper.find('.sort-select')
+    await sortSelect.setValue('name-asc')
+    
+    expect((sortSelect.element as HTMLSelectElement).value).toBe('name-asc')
   })
 })


### PR DESCRIPTION
# KAN-1: Add Sort Button for Audiobooks

## JIRA Issue
https://isurufonseka.atlassian.net/browse/KAN-1

## Summary
This PR adds a dropdown filter that allows users to sort audiobooks by alphabetical order (ascending/descending) or release date (oldest first/newest first).

## Product Manager Summary
Users can now sort the audiobook collection using a new dropdown menu that provides four sorting options:
- Name (A-Z): Sort audiobooks alphabetically from A to Z
- Name (Z-A): Sort audiobooks alphabetically from Z to A
- Release Date (Oldest First): Show oldest releases first
- Release Date (Newest First): Show newest releases first

The sort dropdown is positioned next to the existing search input in the audiobooks header, making it easy for users to find and use.

## Technical Notes

### Changes Made
1. **AudiobooksView.vue**
   - Added `sortOption` ref to track the selected sort option
   - Refactored `filteredAudiobooks` computed property to apply sorting after filtering
   - Implemented `sortAudiobooks()` function with switch statement to handle different sort options
   - Added controls container to group search and sort UI elements
   - Added sort dropdown with 5 options (default, name-asc, name-desc, date-asc, date-desc)
   - Added CSS styles for `.controls-container`, `.sort-container`, and `.sort-select`

2. **AudiobooksView.spec.ts**
   - Fixed test that was looking for removed `.hero` element
   - Added test to verify sort dropdown renders with correct options
   - Added test to verify sort dropdown value changes on selection

### Architecture
```mermaid
graph TD
    A[User Selects Sort Option] --> B[sortOption ref updated]
    B --> C[filteredAudiobooks computed re-evaluates]
    C --> D{searchQuery empty?}
    D -->|Yes| E[Use all audiobooks]
    D -->|No| F[Filter audiobooks by search]
    E --> G[sortAudiobooks function]
    F --> G
    G --> H{sortOption value}
    H -->|name-asc| I[Sort by name A-Z]
    H -->|name-desc| J[Sort by name Z-A]
    H -->|date-asc| K[Sort by release date oldest first]
    H -->|date-desc| L[Sort by release date newest first]
    H -->|default| M[No sorting applied]
    I --> N[Display sorted audiobooks]
    J --> N
    K --> N
    L --> N
    M --> N
```

## Tests
- **Added 2 tests**:
  - `has sort select dropdown`: Verifies the dropdown renders with 5 options
  - `changes sort option when dropdown value changes`: Verifies v-model binding works
- **Fixed 1 test**:
  - Updated `renders the AudiobooksView component` to remove check for non-existent `.hero` element

## Human Testing Instructions
1. Visit http://localhost:5173
2. You should see the audiobooks page with a search input and a new sort dropdown
3. Click the sort dropdown - verify it shows 5 options:
   - Default Order
   - Name (A-Z)
   - Name (Z-A) 
   - Release Date (Oldest First)
   - Release Date (Newest First)
4. Select "Name (A-Z)" - audiobooks should sort alphabetically A to Z
5. Select "Name (Z-A)" - audiobooks should sort alphabetically Z to A
6. Select "Release Date (Oldest First)" - audiobooks should sort by release date, oldest first
7. Select "Release Date (Newest First)" - audiobooks should sort by release date, newest first
8. Try using the search box in combination with sorting - both should work together

## Amp Thread
https://ampcode.com/threads/T-502a58d6-313c-4985-a5b5-7e148c0b2ca2
