### PR TITLE
feat: implement hide audiobook functionality (KAN-3)

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: []
+}>();
+
 const showModal = ref(false);
 
 // Use a separate function to open the modal
@@ -74,10 +78,16 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  emit('hide');
+};
 </script>
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" aria-label="Hide audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -143,6 +153,36 @@ const formatNarrators = (narrators: any[]) => {
   transition: transform 0.3s, box-shadow 0.3s;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
   position: relative;
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: white;
+  font-size: 24px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s, transform 0.2s;
+  padding: 0;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(255, 0, 0, 0.8);
+  transform: scale(1.1);
 }
 
 .audiobook-card:hover {

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,23 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenAudiobookIds = ref<Set<string>>(new Set());
+
+const hideAudiobook = (audiobookId: string) => {
+  hiddenAudiobookIds.value.add(audiobookId);
+};
 
 const filteredAudiobooks = computed(() => {
+  let audiobooks = spotifyStore.audiobooks.filter(
+    audiobook => !hiddenAudiobookIds.value.has(audiobook.id)
+  );
+
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return audiobooks;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return audiobooks.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -72,7 +81,8 @@ onMounted(() => {
           <AudiobookCard 
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
-            :audiobook="audiobook" 
+            :audiobook="audiobook"
+            @hide="hideAudiobook(audiobook.id)"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksView-hide.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView-hide.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import AudiobooksView from '../AudiobooksView.vue'
+
+const mockAudiobooks = [
+  {
+    id: '1',
+    name: 'Test Audiobook 1',
+    authors: [{ name: 'Author 1' }],
+    images: [{ url: 'http://test.com/1.jpg', height: 300, width: 300 }],
+    narrators: [{ name: 'Narrator 1' }],
+    duration_ms: 60000,
+    total_chapters: 10,
+    external_urls: { spotify: 'http://test.com/1' },
+    description: 'Test description 1',
+    publisher: 'Test Publisher 1',
+    type: 'audiobook',
+    uri: 'spotify:audiobook:1',
+    release_date: '2023-01-01'
+  },
+  {
+    id: '2',
+    name: 'Test Audiobook 2',
+    authors: [{ name: 'Author 2' }],
+    images: [{ url: 'http://test.com/2.jpg', height: 300, width: 300 }],
+    narrators: [{ name: 'Narrator 2' }],
+    duration_ms: 120000,
+    total_chapters: 15,
+    external_urls: { spotify: 'http://test.com/2' },
+    description: 'Test description 2',
+    publisher: 'Test Publisher 2',
+    type: 'audiobook',
+    uri: 'spotify:audiobook:2',
+    release_date: '2023-02-01'
+  }
+]
+
+vi.mock('@/stores/spotify', () => ({
+  useSpotifyStore: () => ({
+    audiobooks: mockAudiobooks,
+    isLoading: false,
+    error: null,
+    fetchAudiobooks: vi.fn()
+  })
+}))
+
+vi.mock('@/components/AudiobookCard.vue', () => ({
+  default: {
+    name: 'AudiobookCard',
+    props: ['audiobook'],
+    emits: ['hide'],
+    template: '<div class="audiobook-card-stub" @click="$emit(\'hide\')">{{ audiobook.name }}</div>'
+  }
+}))
+
+describe('AudiobooksView - Hide Functionality', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should hide audiobook when hide event is emitted', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    const cards = wrapper.findAllComponents({ name: 'AudiobookCard' })
+    expect(cards).toHaveLength(2)
+    
+    await cards[0].vm.$emit('hide')
+    await wrapper.vm.$nextTick()
+    
+    const remainingCards = wrapper.findAllComponents({ name: 'AudiobookCard' })
+    expect(remainingCards).toHaveLength(1)
+  })
+
+  it('should maintain hidden state across search operations', async () => {
+    const wrapper = mount(AudiobooksView)
+    
+    const cards = wrapper.findAllComponents({ name: 'AudiobookCard' })
+    await cards[0].vm.$emit('hide')
+    await wrapper.vm.$nextTick()
+    
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('Test')
+    await wrapper.vm.$nextTick()
+    
+    const remainingCards = wrapper.findAllComponents({ name: 'AudiobookCard' })
+    expect(remainingCards).toHaveLength(1)
+  })
+
+  it('should reset hidden audiobooks on page refresh (not persisted)', async () => {
+    const wrapper1 = mount(AudiobooksView)
+    const cards1 = wrapper1.findAllComponents({ name: 'AudiobookCard' })
+    await cards1[0].vm.$emit('hide')
+    await wrapper1.vm.$nextTick()
+    
+    const wrapper2 = mount(AudiobooksView)
+    const cards2 = wrapper2.findAllComponents({ name: 'AudiobookCard' })
+    expect(cards2).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Related Issue
KAN-3 - Hide Audiobooks

## Summary
This PR implements the ability for users to temporarily hide audiobooks they're not interested in by clicking an X button when hovering over them. This allows users to focus on books that matter to them during their current browsing session.

## Technical Notes

### Changes Made
1. **AudiobookCard Component** (`client/src/components/AudiobookCard.vue`)
   - Added a hide button (X) that appears on hover
   - Added `hide` event emitter to notify parent component
   - Styled the button with smooth hover transitions and semi-transparent background
   - Button becomes fully opaque and red on hover for clear visual feedback

2. **AudiobooksView Component** (`client/src/views/AudiobooksView.vue`)
   - Added `hiddenAudiobookIds` Set to track hidden audiobooks in memory
   - Modified `filteredAudiobooks` computed property to exclude hidden audiobooks
   - Added `hideAudiobook` method to handle hide events from AudiobookCard
   - Hidden state is session-only (not persisted to localStorage or backend)

3. **Unit Tests** (`client/src/views/__tests__/AudiobooksView-hide.spec.ts`)
   - Added comprehensive tests for hide functionality
   - Tests verify audiobooks can be hidden
   - Tests verify hidden state persists across search operations
   - Tests verify hidden state is not persisted (resets on component remount)

### Architecture Diagram

```mermaid
sequenceDiagram
    participant User
    participant AudiobooksView
    participant AudiobookCard
    participant HiddenSet
    
    User->>AudiobooksView: Page Load
    AudiobooksView->>AudiobooksView: Initialize hiddenAudiobookIds Set
    AudiobooksView->>AudiobookCard: Render audiobook cards
    
    User->>AudiobookCard: Hover over card
    AudiobookCard->>AudiobookCard: Show X button
    
    User->>AudiobookCard: Click X button
    AudiobookCard->>AudiobooksView: Emit 'hide' event
    AudiobooksView->>HiddenSet: Add audiobook.id
    AudiobooksView->>AudiobooksView: Recompute filteredAudiobooks
    AudiobooksView->>AudiobookCard: Re-render (excluded audiobook hidden)
    
    User->>AudiobooksView: Refresh Page
    AudiobooksView->>AudiobooksView: Reset hiddenAudiobookIds Set
    AudiobooksView->>AudiobookCard: Render all audiobooks (hidden ones reappear)
```

## Testing

### Unit Tests
- **Added 3 tests** for hide functionality:
  1. `should hide audiobook when hide event is emitted`
  2. `should maintain hidden state across search operations`
  3. `should reset hidden audiobooks on page refresh (not persisted)`
- All new tests pass ✅

### Human Testing Instructions
1. Visit http://localhost:5173/ (dev server)
2. Hover over any audiobook card
3. **Expected**: An X button appears in the top-right corner of the card
4. Click the X button
5. **Expected**: The audiobook disappears immediately from the list
6. Search for other audiobooks and verify the hidden one stays hidden
7. **Expected**: Hidden audiobook remains hidden during search
8. Refresh the page (F5 or Cmd+R)
9. **Expected**: Previously hidden audiobook reappears in the list

## Acceptance Criteria
✅ Given I am viewing the book list, when I hover over a book, then an X button appears  
✅ Given the X button is visible, when I click it, then that book is immediately removed from view  
✅ Given I have hidden one or more books, when I refresh the page, then all previously hidden books reappear in the list  
✅ The hidden state is not persisted (no backend/localStorage storage required)
