### PR TITLE
KAN-3: Hide Audiobooks

### DIFF
--- a/client/src/components/AudiobookCard.vue
+++ b/client/src/components/AudiobookCard.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
   audiobook: Audiobook
 }>();
 
+const emit = defineEmits<{
+  hide: []
+}>();
+
 const showModal = ref(false);
 
 // Use a separate function to open the modal
@@ -74,10 +78,17 @@ const formatNarrators = (narrators: any[]) => {
     return 'Narrator';
   }).join(', ');
 };
+
+const handleHide = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  emit('hide');
+};
 </script>
 
 <template>
   <div class="audiobook-card">
+    <button class="hide-btn" @click="handleHide" title="Hide this audiobook">×</button>
     <div class="audiobook-image" @click.stop="toggleModal">
       <img v-if="audiobook.images && audiobook.images.length" :src="audiobook.images[0].url" :alt="audiobook.name" />
       <div v-else class="no-image">No Image</div>
@@ -143,6 +154,36 @@ const formatNarrators = (narrators: any[]) => {
   transition: transform 0.3s, box-shadow 0.3s;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
   position: relative;
+}
+
+.hide-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  color: white;
+  font-size: 24px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s, background 0.2s, transform 0.2s;
+  padding: 0;
+}
+
+.audiobook-card:hover .hide-btn {
+  opacity: 1;
+}
+
+.hide-btn:hover {
+  background: rgba(255, 0, 0, 0.8);
+  transform: scale(1.1);
 }
 
 .audiobook-card:hover {

--- a/client/src/views/AudiobooksView.vue
+++ b/client/src/views/AudiobooksView.vue
@@ -5,14 +5,17 @@ import AudiobookCard from '@/components/AudiobookCard.vue';
 
 const spotifyStore = useSpotifyStore();
 const searchQuery = ref('');
+const hiddenAudiobookIds = ref<Set<string>>(new Set());
 
 const filteredAudiobooks = computed(() => {
+  let books = spotifyStore.audiobooks.filter(audiobook => !hiddenAudiobookIds.value.has(audiobook.id));
+  
   if (!searchQuery.value.trim()) {
-    return spotifyStore.audiobooks;
+    return books;
   }
   
   const query = searchQuery.value.toLowerCase().trim();
-  return spotifyStore.audiobooks.filter(audiobook => {
+  return books.filter(audiobook => {
     // Search by audiobook name
     if (audiobook.name.toLowerCase().includes(query)) {
       return true;
@@ -36,6 +39,10 @@ const filteredAudiobooks = computed(() => {
     return authorMatch || narratorMatch;
   });
 });
+
+const handleHideAudiobook = (audiobookId: string) => {
+  hiddenAudiobookIds.value.add(audiobookId);
+};
 
 onMounted(() => {
   spotifyStore.fetchAudiobooks();
@@ -73,6 +80,7 @@ onMounted(() => {
             v-for="audiobook in filteredAudiobooks" 
             :key="audiobook.id" 
             :audiobook="audiobook" 
+            @hide="handleHideAudiobook(audiobook.id)"
           />
         </div>
       </div>

--- a/client/src/views/__tests__/AudiobooksView-hide.spec.ts
+++ b/client/src/views/__tests__/AudiobooksView-hide.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudiobooksView from '../AudiobooksView.vue'
+
+const mockStore = {
+  audiobooks: [
+    {
+      id: '1',
+      name: 'Test Book 1',
+      authors: [{ name: 'Author 1' }],
+      images: [],
+      narrators: [],
+      duration_ms: 1000,
+      total_chapters: 5,
+      external_urls: { spotify: 'https://spotify.com' }
+    },
+    {
+      id: '2',
+      name: 'Test Book 2',
+      authors: [{ name: 'Author 2' }],
+      images: [],
+      narrators: [],
+      duration_ms: 2000,
+      total_chapters: 10,
+      external_urls: { spotify: 'https://spotify.com' }
+    }
+  ],
+  isLoading: false,
+  error: null,
+  fetchAudiobooks: vi.fn()
+}
+
+vi.mock('@/stores/spotify', () => ({
+  useSpotifyStore: () => mockStore
+}))
+
+vi.mock('@/components/AudiobookCard.vue', () => ({
+  default: {
+    name: 'AudiobookCard',
+    props: ['audiobook'],
+    emits: ['hide'],
+    template: '<div class="audiobook-card-stub" @click="$emit(\'hide\')">{{ audiobook.name }}</div>'
+  }
+}))
+
+describe('AudiobooksView - Hide Functionality', () => {
+  beforeEach(() => {
+    mockStore.audiobooks = [
+      {
+        id: '1',
+        name: 'Test Book 1',
+        authors: [{ name: 'Author 1' }],
+        images: [],
+        narrators: [],
+        duration_ms: 1000,
+        total_chapters: 5,
+        external_urls: { spotify: 'https://spotify.com' }
+      },
+      {
+        id: '2',
+        name: 'Test Book 2',
+        authors: [{ name: 'Author 2' }],
+        images: [],
+        narrators: [],
+        duration_ms: 2000,
+        total_chapters: 10,
+        external_urls: { spotify: 'https://spotify.com' }
+      }
+    ]
+  })
+
+  it('should hide an audiobook when hide event is emitted', async () => {
+    const wrapper = mount(AudiobooksView)
+    await wrapper.vm.$nextTick()
+
+    const cards = wrapper.findAll('.audiobook-card-stub')
+    expect(cards.length).toBe(2)
+
+    await cards[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const cardsAfterHide = wrapper.findAll('.audiobook-card-stub')
+    expect(cardsAfterHide.length).toBe(1)
+    expect(cardsAfterHide[0].text()).toBe('Test Book 2')
+  })
+
+  it('should keep hidden audiobooks after search', async () => {
+    const wrapper = mount(AudiobooksView)
+    await wrapper.vm.$nextTick()
+
+    const cards = wrapper.findAll('.audiobook-card-stub')
+    await cards[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const searchInput = wrapper.find('.search-input')
+    await searchInput.setValue('Test')
+    await wrapper.vm.$nextTick()
+
+    const cardsAfterSearch = wrapper.findAll('.audiobook-card-stub')
+    expect(cardsAfterSearch.length).toBe(1)
+    expect(cardsAfterSearch[0].text()).toBe('Test Book 2')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the ability for users to temporarily hide audiobooks they're not interested in during their browsing session by clicking an X button that appears on hover.

**JIRA Issue:** KAN-3

## Product Manager Summary

Users can now temporarily hide audiobooks from view by hovering over a book card and clicking the X button that appears. This helps users focus on books that interest them during their current browsing session. Hidden books will reappear when the page is refreshed, as the hidden state is intentionally not persisted.

## Technical Notes

### Changes Made

1. **AudiobookCard.vue**:
   - Added hide button (×) that appears on card hover
   - Implemented `hide` event emitter to notify parent component
   - Added CSS for hide button with smooth opacity transitions
   - Button positioned absolutely in top-right corner with hover effects

2. **AudiobooksView.vue**:
   - Added `hiddenAudiobookIds` reactive Set to track hidden books
   - Modified `filteredAudiobooks` computed property to filter out hidden books
   - Implemented `handleHideAudiobook` function to add books to hidden set
   - Connected AudiobookCard hide event to handler

3. **Testing**:
   - Added comprehensive unit tests (AudiobooksView-hide.spec.ts)
   - Tests verify hiding functionality and persistence across searches
   - All new tests passing

### Implementation Details

The solution uses Vue 3 Composition API with:
- Reactive `Set` for O(1) lookup performance
- Computed property to efficiently filter hidden books
- Event emitter pattern for clean component communication
- No local storage or backend persistence (per requirements)

### Architecture Diagram

```mermaid
sequenceDiagram
    participant U as User
    participant AC as AudiobookCard
    participant AV as AudiobooksView
    participant S as State (hiddenIds)
    
    U->>AC: Hover over card
    AC->>AC: Show X button (CSS)
    U->>AC: Click X button
    AC->>AC: handleHide(event)
    AC->>AV: emit('hide')
    AV->>S: Add book ID to Set
    AV->>AV: Recompute filteredAudiobooks
    AV->>U: Book removed from view
    
    Note over U,S: On page refresh
    U->>AV: Refresh page
    AV->>S: Create new empty Set
    AV->>U: All books visible again
```

## Testing

### Unit Tests

**Added 2 tests:**
- ✅ `should hide an audiobook when hide event is emitted`
- ✅ `should keep hidden audiobooks after search`

### Human Testing Instructions

1. Visit http://localhost:5173/ (dev server)
2. Hover over any audiobook card
3. Expected: X button appears in top-right corner
4. Click the X button
5. Expected: Book immediately disappears from view
6. Hide 2-3 more books
7. Use the search bar to filter books
8. Expected: Hidden books remain hidden during search
9. Refresh the page (Cmd+R / Ctrl+R)
10. Expected: All previously hidden books reappear

## Acceptance Criteria

- ✅ X button appears when hovering over a book
- ✅ Clicking X immediately removes book from view
- ✅ Hidden books reappear on page refresh
- ✅ Hidden state is not persisted (session-only)
